### PR TITLE
docs: correct current stable tooling baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,17 @@ See [`docs/architecture.md`](docs/architecture.md).
 
 ## Tooling direction
 
-The modernization work targets a current, conservative stack:
+As of September 10, 2026, the modernization work targets a current, conservative stack:
 
 - **Node 24 LTS** for automation and development.
 - **pnpm workspaces** for deterministic monorepo dependency management.
-- **TypeScript 7** with strict compiler settings and advanced types where they encode real invariants.
-- **React 19** for application UI.
-- **Vite 8** for the web build.
+- **TypeScript 6** in strict mode, resolving its migration deprecations now so the codebase is ready for the upcoming native TypeScript 7 compiler.
+- **React 19.3** for application UI.
+- **Vite 8.1** for the web build.
 - **Vitest 5** for unit/property tests.
 - **Playwright** for browser acceptance and accessibility-critical flows.
 - **Three.js-compatible rendering** for the vector 3D scene.
-- **Tauri 2 + Rust**, only where native capabilities materially improve the game.
+- **Tauri 2.11.x + Rust**, only where native capabilities materially improve the game.
 
 Exact patch versions belong in the generated lockfile during the workspace migration. Generated dependency files must never be hand-edited through a connector.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -295,18 +295,20 @@ Tauri commands must be narrow, permission-minimized, validated, and versioned at
 
 ## Tooling baseline
 
-Target stack for the migration tracked by #1:
+As of September 10, 2026, the target stack for the migration tracked by #1 is:
 
 - Node 24 LTS;
 - pnpm workspaces;
-- TypeScript 7 strict mode;
-- React 19;
-- Vite 8;
+- TypeScript 6 strict mode, with TypeScript 7 migration compatibility treated as a design constraint;
+- React 19.3;
+- Vite 8.1;
 - Vitest 5;
 - Playwright;
 - ESLint flat configuration;
 - Three.js-compatible renderer;
-- Tauri 2/Rust only when native capability work begins.
+- Tauri 2.11.x/Rust only when native capability work begins.
+
+TypeScript 6 is intentionally the current baseline: it is the stable transition release for the upcoming native TypeScript 7 compiler. Resolve its documented deprecations instead of relying on settings TypeScript 7 removes.
 
 Use exact versions from the generated lockfile, not README prose, as the reproducible source of package versions.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,12 +31,12 @@ packages/audio
 packages/config
 ```
 
-Tooling baseline:
+Current baseline as of September 10, 2026:
 
 - Node 24 LTS;
 - pinned pnpm workspace;
-- TypeScript 7 strict mode;
-- React 19 + Vite 8;
+- TypeScript 6 strict mode, configured for a clean future move to the native TypeScript 7 compiler;
+- React 19.3 + Vite 8.1;
 - Vitest 5;
 - Playwright;
 - ESLint flat config and explicit formatting checks.


### PR DESCRIPTION
## Outcome

Correct the revival documentation to use the actual stable TypeScript baseline as of September 10, 2026.

TypeScript 6.0 is the current stable transition release; TypeScript 7 remains the upcoming native compiler. The workspace should therefore start on strict TypeScript 6, resolve its documented migration deprecations, and remain intentionally ready for a narrow TypeScript 7 upgrade when stable.

This also makes the current-family references more precise: React 19.3, Vite 8.1, Vitest 5, Node 24 LTS, and Tauri 2.11.x when/if the native shell is introduced.

Updates #1.

## Validation

Documentation only. Version state was rechecked against official TypeScript, React, Vite, Vitest, Node.js, and Tauri release sources on 2026-09-10. No generated files or dependencies changed.