### PR TITLE
feat(simulation): implement deterministic classic day engine

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import tseslint from "typescript-eslint";
 
 const typedSources = ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}"];
+const scopeTypedConfig = (config) => ({ ...config, files: typedSources });
 
 export default tseslint.config(
   {
@@ -9,12 +10,13 @@ export default tseslint.config(
       "build/**",
       "dist/**",
       "node_modules/**",
+      "public/**",
       "*.js",
       "legacy/**",
     ],
   },
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked.map(scopeTypedConfig),
+  ...tseslint.configs.stylisticTypeChecked.map(scopeTypedConfig),
   {
     files: typedSources,
     languageOptions: {

--- a/packages/simulation/src/environment.ts
+++ b/packages/simulation/src/environment.ts
@@ -1,0 +1,105 @@
+import type { DayEnvironment, DayEvent, MarketSentiment, Weather } from "./model.js";
+import { basisPoints, type DayNumber } from "./primitives.js";
+import type { RandomSource } from "./rng.js";
+
+const SUNNY = Object.freeze({
+  kind: "sunny",
+  demandMultiplier: basisPoints(10_000),
+}) satisfies Weather;
+const CLOUDY = Object.freeze({
+  kind: "cloudy",
+  demandMultiplier: basisPoints(7_000),
+}) satisfies Weather;
+const HOT_AND_DRY = Object.freeze({
+  kind: "hot-and-dry",
+  demandMultiplier: basisPoints(20_000),
+}) satisfies Weather;
+const THUNDERSTORM = Object.freeze({
+  kind: "thunderstorm",
+  demandMultiplier: basisPoints(0),
+}) satisfies Weather;
+
+const VERY_COLD = Object.freeze({
+  kind: "very-cold",
+  demandMultiplier: basisPoints(8_500),
+}) satisfies MarketSentiment;
+const COLD = Object.freeze({
+  kind: "cold",
+  demandMultiplier: basisPoints(9_250),
+}) satisfies MarketSentiment;
+const NEUTRAL = Object.freeze({
+  kind: "neutral",
+  demandMultiplier: basisPoints(10_000),
+}) satisfies MarketSentiment;
+const WARM = Object.freeze({
+  kind: "warm",
+  demandMultiplier: basisPoints(10_750),
+}) satisfies MarketSentiment;
+const HOT = Object.freeze({
+  kind: "hot",
+  demandMultiplier: basisPoints(11_500),
+}) satisfies MarketSentiment;
+
+const NO_EVENT = Object.freeze({
+  kind: "none",
+  demandMultiplier: basisPoints(10_000),
+}) satisfies DayEvent;
+const STREET_WORK = Object.freeze({
+  kind: "street-work",
+  demandMultiplier: basisPoints(4_000),
+}) satisfies DayEvent;
+const WORKERS_BUY_OUT = Object.freeze({
+  kind: "workers-buy-out",
+  demandMultiplier: basisPoints(10_000),
+}) satisfies DayEvent;
+
+const chooseWeather = (day: DayNumber, random: RandomSource): Weather => {
+  if (Number(day) <= 2) {
+    return SUNNY;
+  }
+
+  const roll = random.nextInt(0, 100);
+  if (roll < 60) {
+    return SUNNY;
+  }
+  if (roll < 80) {
+    return random.nextInt(0, 20) === 0 ? THUNDERSTORM : CLOUDY;
+  }
+  return HOT_AND_DRY;
+};
+
+const chooseSentiment = (random: RandomSource): MarketSentiment => {
+  const roll = random.nextInt(0, 100);
+  if (roll < 10) return VERY_COLD;
+  if (roll < 30) return COLD;
+  if (roll < 70) return NEUTRAL;
+  if (roll < 90) return WARM;
+  return HOT;
+};
+
+const chooseEvent = (weather: Weather, random: RandomSource): DayEvent => {
+  if (weather.kind === "thunderstorm") {
+    return NO_EVENT;
+  }
+
+  if (random.nextInt(0, 100) >= 3) {
+    return NO_EVENT;
+  }
+
+  return random.nextInt(0, 2) === 0 ? STREET_WORK : WORKERS_BUY_OUT;
+};
+
+export const generateEnvironment = (
+  day: DayNumber,
+  random: RandomSource,
+): DayEnvironment => {
+  const weather = chooseWeather(day, random);
+  return Object.freeze({
+    weather,
+    sentiment: chooseSentiment(random),
+    event: chooseEvent(weather, random),
+  });
+};
+
+export const neutralEnvironment = (): DayEnvironment =>
+  Object.freeze({ weather: SUNNY, sentiment: NEUTRAL, event: NO_EVENT });

--- a/packages/simulation/src/index.ts
+++ b/packages/simulation/src/index.ts
@@ -1,1 +1,9 @@
 export const SIMULATION_SCHEMA_VERSION = 1 as const;
+
+export * from "./environment.js";
+export * from "./model.js";
+export * from "./primitives.js";
+export * from "./rng.js";
+export * from "./rules.js";
+export * from "./simulate.js";
+export * from "./state.js";

--- a/packages/simulation/src/model.ts
+++ b/packages/simulation/src/model.ts
@@ -1,0 +1,84 @@
+import type {
+  BasisPoints,
+  DayNumber,
+  GlassCount,
+  MoneyCents,
+  SignCount,
+} from "./primitives.js";
+
+export type Weather =
+  | Readonly<{ kind: "sunny"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "cloudy"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "hot-and-dry"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "thunderstorm"; demandMultiplier: BasisPoints }>;
+
+export type MarketSentiment =
+  | Readonly<{ kind: "very-cold"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "cold"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "neutral"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "warm"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "hot"; demandMultiplier: BasisPoints }>;
+
+export type DayEvent =
+  | Readonly<{ kind: "none"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "street-work"; demandMultiplier: BasisPoints }>
+  | Readonly<{ kind: "workers-buy-out"; demandMultiplier: BasisPoints }>;
+
+export type DayEnvironment = Readonly<{
+  weather: Weather;
+  sentiment: MarketSentiment;
+  event: DayEvent;
+}>;
+
+export type DayDecision = Readonly<{
+  glasses: GlassCount;
+  signs: SignCount;
+  price: MoneyCents;
+}>;
+
+export type LedgerLineKind =
+  | "revenue"
+  | "production"
+  | "advertising"
+  | "operating-fee"
+  | "tax"
+  | "bank-fee"
+  | "savings-interest"
+  | "loan-interest";
+
+export type LedgerLine = Readonly<{
+  kind: LedgerLineKind;
+  label: string;
+  amount: MoneyCents;
+  direction: "credit" | "debit";
+}>;
+
+export type DailyLedgerEntry = Readonly<{
+  day: DayNumber;
+  decision: DayDecision;
+  environment: DayEnvironment;
+  potentialDemand: GlassCount;
+  sold: GlassCount;
+  revenue: MoneyCents;
+  expenses: MoneyCents;
+  net: number;
+  endingCash: MoneyCents;
+  lines: readonly LedgerLine[];
+}>;
+
+export type ProgressionTier = 0 | 1 | 2 | 3 | 4;
+
+export type GameState = Readonly<{
+  day: DayNumber;
+  cash: MoneyCents;
+  unitCost: MoneyCents;
+  signCost: MoneyCents;
+  tier: ProgressionTier;
+  ledger: readonly DailyLedgerEntry[];
+}>;
+
+export type DayResolution = Readonly<{
+  previousState: GameState;
+  nextState: GameState;
+  entry: DailyLedgerEntry;
+}>;

--- a/packages/simulation/src/model.ts
+++ b/packages/simulation/src/model.ts
@@ -3,6 +3,7 @@ import type {
   DayNumber,
   GlassCount,
   MoneyCents,
+  SignedMoneyCents,
   SignCount,
 } from "./primitives.js";
 
@@ -61,7 +62,7 @@ export type DailyLedgerEntry = Readonly<{
   sold: GlassCount;
   revenue: MoneyCents;
   expenses: MoneyCents;
-  net: number;
+  net: SignedMoneyCents;
   endingCash: MoneyCents;
   lines: readonly LedgerLine[];
 }>;

--- a/packages/simulation/src/primitives.ts
+++ b/packages/simulation/src/primitives.ts
@@ -5,6 +5,7 @@ type Brand<Value, Name extends string> = Value & {
 };
 
 export type MoneyCents = Brand<number, "MoneyCents">;
+export type SignedMoneyCents = Brand<number, "SignedMoneyCents">;
 export type GlassCount = Brand<number, "GlassCount">;
 export type SignCount = Brand<number, "SignCount">;
 export type DayNumber = Brand<number, "DayNumber">;
@@ -27,6 +28,11 @@ const requireNonNegativeInteger = (value: number, name: string): void => {
 export const moneyCents = (value: number): MoneyCents => {
   requireNonNegativeInteger(value, "money cents");
   return value as MoneyCents;
+};
+
+export const signedMoneyCents = (value: number): SignedMoneyCents => {
+  requireSafeInteger(value, "signed money cents");
+  return value as SignedMoneyCents;
 };
 
 export const glassCount = (value: number): GlassCount => {

--- a/packages/simulation/src/primitives.ts
+++ b/packages/simulation/src/primitives.ts
@@ -1,0 +1,64 @@
+declare const brand: unique symbol;
+
+type Brand<Value, Name extends string> = Value & {
+  readonly [brand]: Name;
+};
+
+export type MoneyCents = Brand<number, "MoneyCents">;
+export type GlassCount = Brand<number, "GlassCount">;
+export type SignCount = Brand<number, "SignCount">;
+export type DayNumber = Brand<number, "DayNumber">;
+export type Seed = Brand<number, "Seed">;
+export type BasisPoints = Brand<number, "BasisPoints">;
+
+const requireSafeInteger = (value: number, name: string): void => {
+  if (!Number.isSafeInteger(value)) {
+    throw new RangeError(`${name} must be a safe integer`);
+  }
+};
+
+const requireNonNegativeInteger = (value: number, name: string): void => {
+  requireSafeInteger(value, name);
+  if (value < 0) {
+    throw new RangeError(`${name} must be non-negative`);
+  }
+};
+
+export const moneyCents = (value: number): MoneyCents => {
+  requireNonNegativeInteger(value, "money cents");
+  return value as MoneyCents;
+};
+
+export const glassCount = (value: number): GlassCount => {
+  requireNonNegativeInteger(value, "glass count");
+  return value as GlassCount;
+};
+
+export const signCount = (value: number): SignCount => {
+  requireNonNegativeInteger(value, "sign count");
+  return value as SignCount;
+};
+
+export const dayNumber = (value: number): DayNumber => {
+  requireSafeInteger(value, "day number");
+  if (value < 1) {
+    throw new RangeError("day number must be at least 1");
+  }
+  return value as DayNumber;
+};
+
+export const seed = (value: number): Seed => {
+  requireNonNegativeInteger(value, "seed");
+  if (value > 0xffff_ffff) {
+    throw new RangeError("seed must fit in an unsigned 32-bit integer");
+  }
+  return value as Seed;
+};
+
+export const basisPoints = (value: number): BasisPoints => {
+  requireNonNegativeInteger(value, "basis points");
+  if (value > 100_000) {
+    throw new RangeError("basis points exceed supported simulation range");
+  }
+  return value as BasisPoints;
+};

--- a/packages/simulation/src/rng.ts
+++ b/packages/simulation/src/rng.ts
@@ -1,0 +1,30 @@
+import type { Seed } from "./primitives.js";
+
+export interface RandomSource {
+  nextUnit(): number;
+  nextInt(minInclusive: number, maxExclusive: number): number;
+}
+
+export const createSeededRandom = (initialSeed: Seed): RandomSource => {
+  let state = Number(initialSeed) >>> 0;
+
+  const nextUnit = (): number => {
+    state = (state + 0x6d2b_79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+
+  const nextInt = (minInclusive: number, maxExclusive: number): number => {
+    if (!Number.isSafeInteger(minInclusive) || !Number.isSafeInteger(maxExclusive)) {
+      throw new RangeError("random integer bounds must be safe integers");
+    }
+    if (maxExclusive <= minInclusive) {
+      throw new RangeError("random integer range must be non-empty");
+    }
+    return minInclusive + Math.floor(nextUnit() * (maxExclusive - minInclusive));
+  };
+
+  return Object.freeze({ nextUnit, nextInt });
+};

--- a/packages/simulation/src/rules.ts
+++ b/packages/simulation/src/rules.ts
@@ -1,0 +1,49 @@
+import type { DayEnvironment } from "./model.js";
+import { glassCount, type GlassCount, type MoneyCents, type SignCount } from "./primitives.js";
+
+const REFERENCE_PRICE_CENTS = 10;
+const BASELINE_DEMAND = 30;
+const BELOW_REFERENCE_GAIN = 0.8;
+const ADVERTISING_RESPONSE = 0.5;
+const BASIS_POINTS_SCALE = 10_000;
+
+export const classicPriceDemand = (price: MoneyCents): number => {
+  const priceCents = Number(price);
+  if (priceCents <= 0) {
+    throw new RangeError("price must be greater than zero");
+  }
+
+  if (priceCents < REFERENCE_PRICE_CENTS) {
+    return (
+      ((REFERENCE_PRICE_CENTS - priceCents) / REFERENCE_PRICE_CENTS) *
+        BELOW_REFERENCE_GAIN *
+        BASELINE_DEMAND +
+      BASELINE_DEMAND
+    );
+  }
+
+  return (
+    (REFERENCE_PRICE_CENTS * REFERENCE_PRICE_CENTS * BASELINE_DEMAND) /
+    (priceCents * priceCents)
+  );
+};
+
+export const classicAdvertisingMultiplier = (signs: SignCount): number =>
+  2 - Math.exp(-ADVERTISING_RESPONSE * Number(signs));
+
+const multiplier = (value: number): number => value / BASIS_POINTS_SCALE;
+
+export const potentialDemand = (
+  price: MoneyCents,
+  signs: SignCount,
+  environment: DayEnvironment,
+): GlassCount => {
+  const demand =
+    classicPriceDemand(price) *
+    classicAdvertisingMultiplier(signs) *
+    multiplier(environment.weather.demandMultiplier) *
+    multiplier(environment.sentiment.demandMultiplier) *
+    multiplier(environment.event.demandMultiplier);
+
+  return glassCount(Math.max(0, Math.floor(demand)));
+};

--- a/packages/simulation/src/simulate.ts
+++ b/packages/simulation/src/simulate.ts
@@ -1,0 +1,120 @@
+import type {
+  DailyLedgerEntry,
+  DayDecision,
+  DayEnvironment,
+  DayResolution,
+  GameState,
+  LedgerLine,
+} from "./model.js";
+import {
+  dayNumber,
+  glassCount,
+  moneyCents,
+  signedMoneyCents,
+} from "./primitives.js";
+import { potentialDemand } from "./rules.js";
+import { productionCostForDay } from "./state.js";
+
+export class UnaffordableDecisionError extends Error {
+  public constructor(
+    public readonly requiredCents: number,
+    public readonly availableCents: number,
+  ) {
+    super(`decision costs ${requiredCents} cents but only ${availableCents} are available`);
+    this.name = "UnaffordableDecisionError";
+  }
+}
+
+const decisionExpenses = (state: GameState, decision: DayDecision) =>
+  moneyCents(
+    Number(decision.glasses) * Number(state.unitCost) +
+      Number(decision.signs) * Number(state.signCost),
+  );
+
+const resolveSold = (
+  decision: DayDecision,
+  environment: DayEnvironment,
+  demand: number,
+) => {
+  if (
+    environment.event.kind === "workers-buy-out" &&
+    environment.weather.kind !== "thunderstorm"
+  ) {
+    return decision.glasses;
+  }
+
+  return glassCount(Math.min(Number(decision.glasses), demand));
+};
+
+export const simulateDay = (
+  state: GameState,
+  decision: DayDecision,
+  environment: DayEnvironment,
+): DayResolution => {
+  if (Number(decision.price) <= 0) {
+    throw new RangeError("price must be greater than zero");
+  }
+
+  const expenses = decisionExpenses(state, decision);
+  if (Number(expenses) > Number(state.cash)) {
+    throw new UnaffordableDecisionError(Number(expenses), Number(state.cash));
+  }
+
+  const calculatedDemand = potentialDemand(decision.price, decision.signs, environment);
+  const sold = resolveSold(decision, environment, Number(calculatedDemand));
+  const reportedDemand =
+    environment.event.kind === "workers-buy-out" &&
+    environment.weather.kind !== "thunderstorm"
+      ? glassCount(Math.max(Number(calculatedDemand), Number(decision.glasses)))
+      : calculatedDemand;
+
+  const revenue = moneyCents(Number(sold) * Number(decision.price));
+  const net = signedMoneyCents(Number(revenue) - Number(expenses));
+  const endingCash = moneyCents(Number(state.cash) + Number(net));
+  const nextDay = dayNumber(Number(state.day) + 1);
+
+  const lines: readonly LedgerLine[] = Object.freeze([
+    Object.freeze({
+      kind: "revenue",
+      label: "Lemonade sales",
+      amount: revenue,
+      direction: "credit",
+    }),
+    Object.freeze({
+      kind: "production",
+      label: "Prepared glasses",
+      amount: moneyCents(Number(decision.glasses) * Number(state.unitCost)),
+      direction: "debit",
+    }),
+    Object.freeze({
+      kind: "advertising",
+      label: "Advertising signs",
+      amount: moneyCents(Number(decision.signs) * Number(state.signCost)),
+      direction: "debit",
+    }),
+  ]);
+
+  const entry: DailyLedgerEntry = Object.freeze({
+    day: state.day,
+    decision,
+    environment,
+    potentialDemand: reportedDemand,
+    sold,
+    revenue,
+    expenses,
+    net,
+    endingCash,
+    lines,
+  });
+
+  const nextState: GameState = Object.freeze({
+    day: nextDay,
+    cash: endingCash,
+    unitCost: productionCostForDay(nextDay),
+    signCost: state.signCost,
+    tier: state.tier,
+    ledger: Object.freeze([...state.ledger, entry]),
+  });
+
+  return Object.freeze({ previousState: state, nextState, entry });
+};

--- a/packages/simulation/src/state.ts
+++ b/packages/simulation/src/state.ts
@@ -1,0 +1,19 @@
+import type { GameState } from "./model.js";
+import { dayNumber, moneyCents, type DayNumber, type MoneyCents } from "./primitives.js";
+
+export const productionCostForDay = (day: DayNumber): MoneyCents => {
+  const dayValue = Number(day);
+  if (dayValue <= 2) return moneyCents(2);
+  if (dayValue <= 6) return moneyCents(4);
+  return moneyCents(5);
+};
+
+export const createInitialState = (): GameState =>
+  Object.freeze({
+    day: dayNumber(1),
+    cash: moneyCents(200),
+    unitCost: moneyCents(2),
+    signCost: moneyCents(15),
+    tier: 0,
+    ledger: Object.freeze([]),
+  });

--- a/packages/simulation/test/simulation.test.ts
+++ b/packages/simulation/test/simulation.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  UnaffordableDecisionError,
+  basisPoints,
+  classicAdvertisingMultiplier,
+  classicPriceDemand,
+  createInitialState,
+  createSeededRandom,
+  dayNumber,
+  generateEnvironment,
+  glassCount,
+  moneyCents,
+  neutralEnvironment,
+  seed,
+  signCount,
+  simulateDay,
+  type DayDecision,
+  type DayEnvironment,
+} from "../src/index.js";
+
+const decision = (
+  glasses: number,
+  signs: number,
+  priceCents: number,
+): DayDecision =>
+  Object.freeze({
+    glasses: glassCount(glasses),
+    signs: signCount(signs),
+    price: moneyCents(priceCents),
+  });
+
+describe("classic demand rules", () => {
+  it("preserves the Apple II reference-price curve", () => {
+    expect(classicPriceDemand(moneyCents(10))).toBe(30);
+    expect(classicPriceDemand(moneyCents(5))).toBe(42);
+    expect(classicPriceDemand(moneyCents(20))).toBe(7.5);
+  });
+
+  it("makes advertising useful with diminishing returns", () => {
+    const zero = classicAdvertisingMultiplier(signCount(0));
+    const one = classicAdvertisingMultiplier(signCount(1));
+    const two = classicAdvertisingMultiplier(signCount(2));
+    const ten = classicAdvertisingMultiplier(signCount(10));
+
+    expect(zero).toBe(1);
+    expect(one).toBeGreaterThan(zero);
+    expect(two - one).toBeLessThan(one - zero);
+    expect(ten).toBeLessThan(2);
+  });
+});
+
+describe("day resolution", () => {
+  it("caps sales by prepared inventory and conserves cents", () => {
+    const result = simulateDay(
+      createInitialState(),
+      decision(20, 1, 10),
+      neutralEnvironment(),
+    );
+
+    expect(Number(result.entry.sold)).toBe(20);
+    expect(Number(result.entry.revenue)).toBe(200);
+    expect(Number(result.entry.expenses)).toBe(55);
+    expect(Number(result.entry.net)).toBe(145);
+    expect(Number(result.entry.endingCash)).toBe(345);
+    expect(Number(result.nextState.cash)).toBe(
+      Number(result.previousState.cash) + Number(result.entry.net),
+    );
+  });
+
+  it("rejects spending that exceeds available cash", () => {
+    expect(() =>
+      simulateDay(createInitialState(), decision(100, 1, 10), neutralEnvironment()),
+    ).toThrowError(UnaffordableDecisionError);
+  });
+
+  it("keeps thunderstorms economically decisive without presentation timing", () => {
+    const environment: DayEnvironment = Object.freeze({
+      weather: Object.freeze({
+        kind: "thunderstorm",
+        demandMultiplier: basisPoints(0),
+      }),
+      sentiment: Object.freeze({
+        kind: "hot",
+        demandMultiplier: basisPoints(11_500),
+      }),
+      event: Object.freeze({
+        kind: "none",
+        demandMultiplier: basisPoints(10_000),
+      }),
+    });
+
+    const result = simulateDay(createInitialState(), decision(20, 3, 5), environment);
+    expect(Number(result.entry.sold)).toBe(0);
+  });
+
+  it("models the worker sell-out event without bypassing affordability", () => {
+    const environment: DayEnvironment = Object.freeze({
+      weather: Object.freeze({
+        kind: "cloudy",
+        demandMultiplier: basisPoints(7_000),
+      }),
+      sentiment: Object.freeze({
+        kind: "very-cold",
+        demandMultiplier: basisPoints(8_500),
+      }),
+      event: Object.freeze({
+        kind: "workers-buy-out",
+        demandMultiplier: basisPoints(10_000),
+      }),
+    });
+
+    const result = simulateDay(createInitialState(), decision(25, 0, 50), environment);
+    expect(Number(result.entry.sold)).toBe(25);
+    expect(Number(result.entry.potentialDemand)).toBeGreaterThanOrEqual(25);
+  });
+
+  it("applies the classic staged production-cost lesson", () => {
+    const first = simulateDay(
+      createInitialState(),
+      decision(5, 0, 10),
+      neutralEnvironment(),
+    );
+    const second = simulateDay(
+      first.nextState,
+      decision(5, 0, 10),
+      neutralEnvironment(),
+    );
+
+    expect(Number(first.nextState.unitCost)).toBe(2);
+    expect(Number(second.nextState.unitCost)).toBe(4);
+  });
+
+  it("holds accounting and inventory invariants across a decision grid", () => {
+    const glassesValues = [0, 1, 5, 20, 50] as const;
+    const signValues = [0, 1, 3] as const;
+    const priceValues = [5, 10, 25] as const;
+
+    for (const glasses of glassesValues) {
+      for (const signs of signValues) {
+        for (const price of priceValues) {
+          const result = simulateDay(
+            createInitialState(),
+            decision(glasses, signs, price),
+            neutralEnvironment(),
+          );
+
+          expect(Number(result.entry.sold)).toBeLessThanOrEqual(glasses);
+          expect(Number(result.entry.revenue)).toBe(Number(result.entry.sold) * price);
+          expect(Number(result.entry.endingCash)).toBe(
+            Number(result.previousState.cash) + Number(result.entry.net),
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("deterministic environment generation", () => {
+  it("protects the first two days with sunny weather", () => {
+    const random = createSeededRandom(seed(123));
+    expect(generateEnvironment(dayNumber(1), random).weather.kind).toBe("sunny");
+    expect(generateEnvironment(dayNumber(2), random).weather.kind).toBe("sunny");
+  });
+
+  it("replays the same environment sequence from the same seed", () => {
+    const left = createSeededRandom(seed(0x00c0_ffee));
+    const right = createSeededRandom(seed(0x00c0_ffee));
+
+    const leftSequence = Array.from({ length: 40 }, (_, index) =>
+      generateEnvironment(dayNumber(index + 1), left),
+    );
+    const rightSequence = Array.from({ length: 40 }, (_, index) =>
+      generateEnvironment(dayNumber(index + 1), right),
+    );
+
+    expect(leftSequence).toEqual(rightSequence);
+  });
+});


### PR DESCRIPTION
## Outcome

Implements the first complete pure simulation slice for #2 on top of the workspace bootstrap in #11.

The package now provides:
- branded constructors for non-negative money, signed money deltas, glass/sign counts, day numbers, seeds and basis points;
- closed unions for weather, market sentiment, day events, progression tier and ledger line kinds;
- a deterministic injected Mulberry32-style random source with no ambient `Math.random()`;
- the Apple II-inspired price curve (30 glasses at the 10-cent reference, linear benefit below, inverse-square demand above);
- exponential diminishing-return advertising (`2 - exp(-0.5 * signs)`);
- protected sunny opening days, classic 60/20/20 ordinary weather mix, rare thunderstorm/street-work events and bounded market sentiment;
- classic staged production cost (2¢ -> 4¢ -> 5¢);
- atomic affordability validation, inventory-capped sales, integer-cent accounting and immutable daily ledger entries;
- deterministic environment replay and grid-style invariant tests for accounting and inventory.

## Invariants

- Simulation imports no DOM, React, Three.js, Web Audio, persistence or Tauri APIs.
- Money accounting is integer cents; signed net values are explicitly branded.
- Presentation timing cannot alter results.
- Workers-buy-out can force a sell-out but cannot bypass pre-day affordability.
- Thunderstorm demand remains zero even if sentiment is favorable.

## Stack dependency

Base: `revival/workspace-bootstrap` / PR #11.

This PR is draft only because the stack still lacks the generated `pnpm-lock.yaml`. Once #11 receives its real pnpm lockfile and CI can execute, this PR should run `typecheck`, typed ESLint, Vitest, and build before being marked ready.

Closes #2 when validated and merged into the bootstrap stack.