### PR TITLE
feat(web): ship the three-control daily decision loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,20 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
+
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 12.4.0
+          run_install: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test:e2e

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#f4c542" />
+    <meta
+      name="description"
+      content="Lemonade — three decisions, one day of sales, immediate consequences."
+    />
+    <title>Lemonade</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@lemonade/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@lemonade/simulation": "workspace:*",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.3.0",
+    "@types/react-dom": "^19.3.0",
+    "vite": "^8.1.0"
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,272 @@
+import { useMemo, useState, type FormEvent } from "react";
+
+import {
+  createInitialState,
+  createSeededRandom,
+  dayNumber,
+  generateEnvironment,
+  glassCount,
+  moneyCents,
+  seed,
+  signCount,
+  simulateDay,
+  type DayEnvironment,
+  type DayResolution,
+  type GameState,
+} from "@lemonade/simulation";
+
+type Phase =
+  | Readonly<{ kind: "deciding" }>
+  | Readonly<{ kind: "report"; resolution: DayResolution }>;
+
+const weatherLabel: Record<DayEnvironment["weather"]["kind"], string> = {
+  sunny: "Sunny",
+  cloudy: "Cloudy",
+  "hot-and-dry": "Hot & dry",
+  thunderstorm: "Thunderstorm",
+};
+
+const sentimentLabel: Record<DayEnvironment["sentiment"]["kind"], string> = {
+  "very-cold": "Very cautious",
+  cold: "Cautious",
+  neutral: "Neutral",
+  warm: "Interested",
+  hot: "Eager",
+};
+
+const eventLabel: Record<DayEnvironment["event"]["kind"], string> = {
+  none: "No unusual event",
+  "street-work": "Street work slowed neighborhood traffic",
+  "workers-buy-out": "Road workers bought out the stand",
+};
+
+const moneyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+});
+
+const formatMoney = (cents: number): string => moneyFormatter.format(cents / 100);
+
+const decisionLimit = (state: GameState): Readonly<{ glasses: number; signs: number }> =>
+  Object.freeze({
+    glasses: Math.min(250, Math.floor(Number(state.cash) / Number(state.unitCost))),
+    signs: Math.min(25, Math.floor(Number(state.cash) / Number(state.signCost))),
+  });
+
+export const App = () => {
+  const [random] = useState(() => createSeededRandom(seed(0x1e_ad_2026)));
+  const [game, setGame] = useState<GameState>(() => createInitialState());
+  const [environment, setEnvironment] = useState<DayEnvironment>(() =>
+    generateEnvironment(dayNumber(1), random),
+  );
+  const [phase, setPhase] = useState<Phase>({ kind: "deciding" });
+  const [glasses, setGlasses] = useState(20);
+  const [signs, setSigns] = useState(1);
+  const [price, setPrice] = useState(10);
+
+  const limits = useMemo(() => decisionLimit(game), [game]);
+  const spend = glasses * Number(game.unitCost) + signs * Number(game.signCost);
+  const affordable = spend <= Number(game.cash);
+
+  const sell = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (!affordable || phase.kind !== "deciding") return;
+
+    const resolution = simulateDay(
+      game,
+      Object.freeze({
+        glasses: glassCount(glasses),
+        signs: signCount(signs),
+        price: moneyCents(price),
+      }),
+      environment,
+    );
+    setPhase(Object.freeze({ kind: "report", resolution }));
+  };
+
+  const planNextDay = (): void => {
+    if (phase.kind !== "report") return;
+
+    const nextState = phase.resolution.nextState;
+    setGame(nextState);
+    setEnvironment(generateEnvironment(nextState.day, random));
+    setGlasses((current) => Math.min(current, decisionLimit(nextState).glasses));
+    setSigns((current) => Math.min(current, decisionLimit(nextState).signs));
+    setPhase(Object.freeze({ kind: "deciding" }));
+  };
+
+  return (
+    <main className="game-shell">
+      <header className="topline">
+        <div>
+          <p className="eyebrow">Lemonsville neighborhood market</p>
+          <h1>Lemonade</h1>
+        </div>
+        <dl className="cash-readout" aria-label="Business status">
+          <div>
+            <dt>Day</dt>
+            <dd>{Number(game.day)}</dd>
+          </div>
+          <div>
+            <dt>Cash</dt>
+            <dd>{formatMoney(Number(game.cash))}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <section className="conditions" aria-labelledby="conditions-title">
+        <div>
+          <p className="eyebrow" id="conditions-title">
+            Today’s conditions
+          </p>
+          <strong>{weatherLabel[environment.weather.kind]}</strong>
+        </div>
+        <div>
+          <span>Market sentiment</span>
+          <strong>{sentimentLabel[environment.sentiment.kind]}</strong>
+        </div>
+        <div>
+          <span>Production</span>
+          <strong>{formatMoney(Number(game.unitCost))} / glass</strong>
+        </div>
+        <div>
+          <span>Advertising</span>
+          <strong>{formatMoney(Number(game.signCost))} / sign</strong>
+        </div>
+      </section>
+
+      <section className="stand-stage" aria-label="Lemonade stand activity">
+        <div className={`weather-orb weather-${environment.weather.kind}`} aria-hidden="true" />
+        <div className="street" aria-hidden="true">
+          <div className="house house-left" />
+          <div className="stand">
+            <div className="awning" />
+            <div className="counter">LEMONADE</div>
+          </div>
+          <div className="house house-right" />
+        </div>
+        <p className="scene-equivalent">
+          {weatherLabel[environment.weather.kind]}. {sentimentLabel[environment.sentiment.kind]} customers.
+        </p>
+      </section>
+
+      {phase.kind === "deciding" ? (
+        <form className="decision-panel" onSubmit={sell}>
+          <header className="panel-heading">
+            <div>
+              <p className="eyebrow">Set today’s plan</p>
+              <h2>Three decisions. Then sell.</h2>
+            </div>
+            <p className={affordable ? "spend" : "spend spend-warning"}>
+              Spend {formatMoney(spend)} of {formatMoney(Number(game.cash))}
+            </p>
+          </header>
+
+          <label className="decision-control" htmlFor="glasses">
+            <span>
+              <strong>Glasses</strong>
+              <small>Inventory prepared before demand is known</small>
+            </span>
+            <output htmlFor="glasses">{glasses}</output>
+            <input
+              id="glasses"
+              name="glasses"
+              type="range"
+              min="0"
+              max={limits.glasses}
+              step="1"
+              value={glasses}
+              onChange={(event) => setGlasses(event.currentTarget.valueAsNumber)}
+            />
+          </label>
+
+          <label className="decision-control" htmlFor="signs">
+            <span>
+              <strong>Signs</strong>
+              <small>Advertising helps demand with diminishing returns</small>
+            </span>
+            <output htmlFor="signs">{signs}</output>
+            <input
+              id="signs"
+              name="signs"
+              type="range"
+              min="0"
+              max={limits.signs}
+              step="1"
+              value={signs}
+              onChange={(event) => setSigns(event.currentTarget.valueAsNumber)}
+            />
+          </label>
+
+          <label className="decision-control" htmlFor="price">
+            <span>
+              <strong>Price</strong>
+              <small>Higher margin can sharply reduce demand</small>
+            </span>
+            <output htmlFor="price">{formatMoney(price)}</output>
+            <input
+              id="price"
+              name="price"
+              type="range"
+              min="1"
+              max="100"
+              step="1"
+              value={price}
+              onChange={(event) => setPrice(event.currentTarget.valueAsNumber)}
+            />
+          </label>
+
+          {!affordable && (
+            <p className="inline-error" role="alert">
+              This plan costs more cash than the stand has. Reduce glasses or signs.
+            </p>
+          )}
+
+          <button className="sell-button" type="submit" disabled={!affordable}>
+            Sell for the day
+          </button>
+        </form>
+      ) : (
+        <section className="report-panel" aria-live="polite" aria-labelledby="report-title">
+          <header className="panel-heading">
+            <div>
+              <p className="eyebrow">Day {Number(phase.resolution.entry.day)} report</p>
+              <h2 id="report-title">
+                {Number(phase.resolution.entry.sold)} of {Number(phase.resolution.entry.decision.glasses)} sold
+              </h2>
+            </div>
+            <strong className={Number(phase.resolution.entry.net) >= 0 ? "profit" : "loss"}>
+              {Number(phase.resolution.entry.net) >= 0 ? "+" : "−"}
+              {formatMoney(Math.abs(Number(phase.resolution.entry.net)))}
+            </strong>
+          </header>
+
+          <dl className="results-grid">
+            <div>
+              <dt>Revenue</dt>
+              <dd>{formatMoney(Number(phase.resolution.entry.revenue))}</dd>
+            </div>
+            <div>
+              <dt>Expenses</dt>
+              <dd>{formatMoney(Number(phase.resolution.entry.expenses))}</dd>
+            </div>
+            <div>
+              <dt>Ending cash</dt>
+              <dd>{formatMoney(Number(phase.resolution.entry.endingCash))}</dd>
+            </div>
+            <div>
+              <dt>Potential demand</dt>
+              <dd>{Number(phase.resolution.entry.potentialDemand)}</dd>
+            </div>
+          </dl>
+
+          <p className="event-note">{eventLabel[phase.resolution.entry.environment.event.kind]}</p>
+          <button className="next-button" type="button" onClick={planNextDay}>
+            Plan next day
+          </button>
+        </section>
+      )}
+    </main>
+  );
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App.js";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (root === null) {
+  throw new Error("Application root is missing");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,476 @@
+:root {
+  font-family: "Avenir Next", "Segoe UI", system-ui, sans-serif;
+  color: #211d14;
+  background: #f2e8c8;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 15% 10%, rgb(255 255 255 / 55%), transparent 26rem),
+    linear-gradient(180deg, #f3df97 0%, #f5edcf 42%, #c8d7a2 100%);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid #1d6d5d;
+  outline-offset: 4px;
+}
+
+.game-shell {
+  width: min(1100px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 28px 0 52px;
+}
+
+.topline,
+.panel-heading,
+.conditions,
+.results-grid {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+h1,
+h2,
+p,
+dl,
+dd {
+  margin: 0;
+}
+
+h1 {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: clamp(2.4rem, 8vw, 5.8rem);
+  line-height: 0.9;
+  letter-spacing: -0.08em;
+  text-transform: uppercase;
+}
+
+h2 {
+  max-width: 18ch;
+  font-size: clamp(1.4rem, 3.2vw, 2.3rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.eyebrow,
+.conditions span,
+.cash-readout dt,
+.results-grid dt {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin-bottom: 8px;
+  color: #3f5944;
+}
+
+.cash-readout {
+  display: flex;
+  gap: 10px;
+}
+
+.cash-readout > div {
+  min-width: 92px;
+  padding: 12px 14px;
+  border: 2px solid #211d14;
+  background: rgb(255 250 226 / 80%);
+  box-shadow: 4px 4px 0 #211d14;
+}
+
+.cash-readout dd {
+  margin-top: 4px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.conditions {
+  margin: 26px 0 18px;
+  padding: 16px 18px;
+  border: 2px solid #211d14;
+  background: #f7cf52;
+  box-shadow: 6px 6px 0 #211d14;
+}
+
+.conditions > div {
+  display: grid;
+  gap: 5px;
+}
+
+.conditions strong {
+  font-size: 1rem;
+}
+
+.stand-stage {
+  position: relative;
+  overflow: hidden;
+  min-height: 310px;
+  border: 2px solid #211d14;
+  background: linear-gradient(180deg, #7bc6d6 0 58%, #9cb976 58% 76%, #b99a71 76%);
+  box-shadow: 8px 8px 0 #211d14;
+  isolation: isolate;
+}
+
+.weather-orb {
+  position: absolute;
+  top: 34px;
+  right: 8%;
+  width: 68px;
+  height: 68px;
+  border: 3px solid #211d14;
+  border-radius: 50%;
+  background: #f9cc3b;
+  box-shadow: 8px 8px 0 rgb(33 29 20 / 18%);
+}
+
+.weather-cloudy,
+.weather-thunderstorm {
+  width: 105px;
+  height: 48px;
+  border-radius: 30px;
+  background: #c6d1cf;
+}
+
+.weather-cloudy::before,
+.weather-thunderstorm::before {
+  position: absolute;
+  top: -26px;
+  left: 18px;
+  width: 52px;
+  height: 52px;
+  border: 3px solid #211d14;
+  border-bottom: 0;
+  border-radius: 50% 50% 0 0;
+  background: inherit;
+  content: "";
+}
+
+.weather-hot-and-dry {
+  width: 82px;
+  height: 82px;
+  background: #ffb633;
+  box-shadow: 0 0 0 12px rgb(249 204 59 / 30%);
+}
+
+.weather-thunderstorm {
+  background: #657786;
+}
+
+.weather-thunderstorm::after {
+  position: absolute;
+  top: 38px;
+  left: 52px;
+  width: 14px;
+  height: 42px;
+  background: #f8d346;
+  clip-path: polygon(45% 0, 100% 0, 62% 40%, 92% 40%, 20% 100%, 38% 55%, 0 55%);
+  content: "";
+}
+
+.street {
+  position: absolute;
+  inset: auto 5% 20px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+}
+
+.house,
+.stand {
+  position: relative;
+  border: 3px solid #211d14;
+  box-shadow: 7px 7px 0 rgb(33 29 20 / 20%);
+}
+
+.house {
+  width: 150px;
+  height: 112px;
+  background: #e37a58;
+}
+
+.house::before {
+  position: absolute;
+  top: -63px;
+  left: -10px;
+  width: 166px;
+  height: 64px;
+  border: 3px solid #211d14;
+  background: #8c4d4a;
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  content: "";
+}
+
+.house::after {
+  position: absolute;
+  bottom: 0;
+  left: 56px;
+  width: 38px;
+  height: 68px;
+  border: 3px solid #211d14;
+  border-bottom: 0;
+  background: #5d7d7a;
+  content: "";
+}
+
+.house-right {
+  transform: scale(0.84);
+  background: #d7b068;
+}
+
+.stand {
+  width: min(330px, 44vw);
+  min-width: 230px;
+  height: 185px;
+  background: #f0d285;
+}
+
+.awning {
+  position: absolute;
+  top: -35px;
+  left: -18px;
+  width: calc(100% + 36px);
+  height: 48px;
+  border: 3px solid #211d14;
+  background: repeating-linear-gradient(90deg, #f7e8b8 0 36px, #e3a538 36px 72px);
+  transform: perspective(160px) rotateX(-12deg);
+}
+
+.counter {
+  position: absolute;
+  right: 14px;
+  bottom: 22px;
+  left: 14px;
+  padding: 12px 8px;
+  border: 3px solid #211d14;
+  background: #f8eab9;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: clamp(1.1rem, 3.8vw, 2.4rem);
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-align: center;
+}
+
+.scene-equivalent {
+  position: absolute;
+  left: 12px;
+  bottom: 10px;
+  z-index: -1;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.decision-panel,
+.report-panel {
+  margin-top: 22px;
+  padding: clamp(18px, 4vw, 34px);
+  border: 2px solid #211d14;
+  background: #fff9e4;
+  box-shadow: 8px 8px 0 #211d14;
+}
+
+.panel-heading {
+  align-items: end;
+  margin-bottom: 24px;
+}
+
+.spend {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-weight: 800;
+}
+
+.spend-warning,
+.loss,
+.inline-error {
+  color: #9a2e26;
+}
+
+.decision-control {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(64px, auto) minmax(220px, 2fr);
+  align-items: center;
+  gap: 20px;
+  padding: 21px 0;
+  border-top: 2px solid #d9cda9;
+}
+
+.decision-control > span {
+  display: grid;
+  gap: 4px;
+}
+
+.decision-control strong {
+  font-size: 1.12rem;
+}
+
+.decision-control small {
+  max-width: 35ch;
+  color: #655f50;
+}
+
+.decision-control output {
+  min-width: 72px;
+  padding: 8px 10px;
+  border: 2px solid #211d14;
+  background: #f8d354;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-weight: 900;
+  text-align: center;
+}
+
+input[type="range"] {
+  width: 100%;
+  accent-color: #236f5e;
+  cursor: ew-resize;
+}
+
+.inline-error {
+  margin: 4px 0 14px;
+  font-weight: 750;
+}
+
+.sell-button,
+.next-button {
+  width: 100%;
+  min-height: 58px;
+  border: 3px solid #211d14;
+  background: #236f5e;
+  color: #fffbee;
+  box-shadow: 5px 5px 0 #211d14;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+
+.sell-button:hover:not(:disabled),
+.next-button:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 7px 7px 0 #211d14;
+}
+
+.sell-button:active:not(:disabled),
+.next-button:active {
+  transform: translate(3px, 3px);
+  box-shadow: 2px 2px 0 #211d14;
+}
+
+.sell-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.profit,
+.loss {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: clamp(1.6rem, 5vw, 3rem);
+}
+
+.profit {
+  color: #236f5e;
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin: 22px 0;
+}
+
+.results-grid > div {
+  min-height: 82px;
+  padding: 15px;
+  border: 2px solid #211d14;
+  background: #f6df8f;
+}
+
+.results-grid dd {
+  margin-top: 8px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+.event-note {
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  border-left: 5px solid #e3a538;
+  background: #f5edd1;
+}
+
+@media (max-width: 760px) {
+  .game-shell {
+    width: min(100% - 20px, 620px);
+    padding-top: 18px;
+  }
+
+  .topline,
+  .panel-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .conditions {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .stand-stage {
+    min-height: 245px;
+  }
+
+  .house {
+    display: none;
+  }
+
+  .street {
+    justify-content: center;
+  }
+
+  .stand {
+    width: min(78vw, 330px);
+  }
+
+  .decision-control {
+    grid-template-columns: 1fr auto;
+  }
+
+  .decision-control input {
+    grid-column: 1 / -1;
+  }
+
+  .results-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/e2e/daily-loop.spec.ts
+++ b/e2e/daily-loop.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+test("plays a complete day with keyboard controls", async ({ page }) => {
+  await page.goto("/");
+
+  const sliders = page.getByRole("slider");
+  await expect(sliders).toHaveCount(3);
+  await expect(page.getByRole("button", { name: "Sell for the day" })).toHaveCount(1);
+
+  const glasses = page.getByRole("slider", { name: /Glasses/ });
+  await glasses.focus();
+  await page.keyboard.press("ArrowRight");
+
+  const sell = page.getByRole("button", { name: "Sell for the day" });
+  await sell.focus();
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByRole("heading", { name: /sold$/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Plan next day" })).toBeVisible();
+});
+
+test("prevents an unaffordable plan before submission", async ({ page }) => {
+  await page.goto("/");
+
+  const glasses = page.getByRole("slider", { name: /Glasses/ });
+  const signs = page.getByRole("slider", { name: /Signs/ });
+  await glasses.focus();
+  await page.keyboard.press("End");
+  await signs.focus();
+  await page.keyboard.press("End");
+
+  await expect(page.getByRole("alert")).toContainText("costs more cash");
+  await expect(page.getByRole("button", { name: "Sell for the day" })).toBeDisabled();
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const typedSources = [
   "e2e/**/*.ts",
   "*.config.ts",
 ];
+const scopeTypedConfig = (config) => ({ ...config, files: typedSources });
 
 export default tseslint.config(
   {
@@ -14,12 +15,13 @@ export default tseslint.config(
       "build/**",
       "dist/**",
       "node_modules/**",
+      "public/**",
       "*.js",
       "legacy/**",
     ],
   },
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked.map(scopeTypedConfig),
+  ...tseslint.configs.stylisticTypeChecked.map(scopeTypedConfig),
   {
     files: typedSources,
     languageOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,11 @@
 import tseslint from "typescript-eslint";
 
-const typedSources = ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}"];
+const typedSources = [
+  "apps/**/*.{ts,tsx}",
+  "packages/**/*.{ts,tsx}",
+  "e2e/**/*.ts",
+  "*.config.ts",
+];
 
 export default tseslint.config(
   {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@eslint/js": "^10.10.0",
     "@playwright/test": "^1.63.0",
+    "@types/node": "^24.0.0",
     "eslint": "^10.10.0",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.70.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "pnpm --filter @lemonade/web dev",
     "build": "pnpm -r --if-present build",
-    "typecheck": "pnpm -r --if-present typecheck",
+    "typecheck": "tsc -p tsconfig.json --noEmit && pnpm -r --if-present typecheck",
     "lint": "eslint .",
     "test": "pnpm -r --if-present test",
     "test:e2e": "playwright test",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "pnpm -r --if-present typecheck",
     "lint": "eslint .",
     "test": "pnpm -r --if-present test",
+    "test:e2e": "playwright test",
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "@playwright/test";
 
+const isCI = Boolean(process.env["CI"]);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? "github" : "list",
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  reporter: isCI ? "github" : "list",
   use: {
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
@@ -13,6 +15,6 @@ export default defineConfig({
   webServer: {
     command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./public/",
-    "sourceMap": true,
-    "noImplicitAny": true,
-    "module": "commonjs",
-    // "module": "es6",
-    "target": "es6",
-    // "allowJs": true,
-    // "removeComments": true,
-    // "declaration": true,
-    "pretty": true
-    // "strict": true
+    "noEmit": true,
+    "types": ["node", "@playwright/test"]
   },
-  "include": ["app"],
-  "exclude": ["node_modules"],
-  "types": []
+  "include": ["playwright.config.ts", "e2e/**/*.ts"]
 }


### PR DESCRIPTION
## Outcome

Implements #3 as the first playable React surface, stacked directly on the deterministic simulation PR #12.

The deciding phase exposes exactly three player-controlled variables:
1. glasses to prepare;
2. advertising signs;
3. price per glass;

and exactly one primary commit action: `Sell for the day`.

Weather, market sentiment, cash, production cost and advertising cost are visible information rather than extra controls. Affordability is calculated before submission and blocks the Sell action inline without modal interruption.

After commit, the UI moves to a separate immutable report phase showing sold/prepared, potential demand, revenue, expenses, net result, ending cash and the material day event. `Plan next day` advances out of the report; it is not part of the operating decision surface.

## Presentation

Adds a responsive retro-futurist baseline with a lightweight vector/CSS neighborhood fallback. This is intentionally not the final Three.js scene: #4 owns the typed 3D adapter. The fallback already communicates weather textually and remains useful without WebGL.

## Accessibility / acceptance

- native range controls support keyboard precision;
- no mandatory gestures or hover-only information;
- explicit labels/outputs and `aria-live` report state;
- reduced-motion behavior included;
- Playwright verifies exactly three sliders + one Sell button, a keyboard-only day, and pre-submit unaffordable-plan blocking;
- CI gains a separate Chromium acceptance job.

## Stack dependency

Base: `revival/deterministic-simulation` / PR #12, which itself depends on draft bootstrap PR #11.

This PR remains draft until #11 receives a generated pnpm lockfile and the stack can execute typecheck, typed lint, unit tests, build and Playwright.

Closes #3 when validated and merged through the stack.