### PR TITLE
feat(scene): add typed low-poly Lemonsville renderer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@lemonade/scene": "workspace:*",
     "@lemonade/simulation": "workspace:*",
     "react": "^19.3.0",
     "react-dom": "^19.3.0"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,8 @@ import {
   type GameState,
 } from "@lemonade/simulation";
 
+import { LemonsvilleScene } from "./LemonsvilleScene.js";
+
 type Phase =
   | Readonly<{ kind: "deciding" }>
   | Readonly<{ kind: "report"; resolution: DayResolution }>;
@@ -96,6 +98,12 @@ export const App = () => {
     setPhase(Object.freeze({ kind: "deciding" }));
   };
 
+  const sceneSigns =
+    phase.kind === "report" ? Number(phase.resolution.entry.decision.signs) : signs;
+  const sceneSold = phase.kind === "report" ? Number(phase.resolution.entry.sold) : 0;
+  const scenePrepared =
+    phase.kind === "report" ? Number(phase.resolution.entry.decision.glasses) : glasses;
+
   return (
     <main className="game-shell">
       <header className="topline">
@@ -136,20 +144,13 @@ export const App = () => {
         </div>
       </section>
 
-      <section className="stand-stage" aria-label="Lemonade stand activity">
-        <div className={`weather-orb weather-${environment.weather.kind}`} aria-hidden="true" />
-        <div className="street" aria-hidden="true">
-          <div className="house house-left" />
-          <div className="stand">
-            <div className="awning" />
-            <div className="counter">LEMONADE</div>
-          </div>
-          <div className="house house-right" />
-        </div>
-        <p className="scene-equivalent">
-          {weatherLabel[environment.weather.kind]}. {sentimentLabel[environment.sentiment.kind]} customers.
-        </p>
-      </section>
+      <LemonsvilleScene
+        environment={environment}
+        visibleSigns={sceneSigns}
+        phase={phase.kind}
+        sold={sceneSold}
+        prepared={scenePrepared}
+      />
 
       {phase.kind === "deciding" ? (
         <form className="decision-panel" onSubmit={sell}>

--- a/apps/web/src/LemonsvilleScene.tsx
+++ b/apps/web/src/LemonsvilleScene.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  createLemonsvilleScene,
+  type CustomerActivity,
+  type LemonsvilleSceneController,
+  type LemonsvilleSceneState,
+} from "@lemonade/scene";
+import type { DayEnvironment } from "@lemonade/simulation";
+
+const activityBySentiment: Record<DayEnvironment["sentiment"]["kind"], CustomerActivity> = {
+  "very-cold": "quiet",
+  cold: "light",
+  neutral: "steady",
+  warm: "lively",
+  hot: "busy",
+};
+
+type LemonsvilleSceneProps = Readonly<{
+  environment: DayEnvironment;
+  visibleSigns: number;
+  phase: "deciding" | "report";
+  sold: number;
+  prepared: number;
+}>;
+
+export const LemonsvilleScene = ({
+  environment,
+  visibleSigns,
+  phase,
+  sold,
+  prepared,
+}: LemonsvilleSceneProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const controllerRef = useRef<LemonsvilleSceneController | null>(null);
+  const [fallback, setFallback] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(() =>
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  const sceneState = useMemo<LemonsvilleSceneState>(
+    () =>
+      Object.freeze({
+        weather: environment.weather.kind,
+        customerActivity: activityBySentiment[environment.sentiment.kind],
+        visibleSigns,
+        sellThroughBasisPoints:
+          prepared > 0 ? Math.round((Math.max(0, sold) / prepared) * 10_000) : 0,
+        phase,
+        reducedMotion,
+      }),
+    [environment, visibleSigns, phase, sold, prepared, reducedMotion],
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (): void => setReducedMotion(media.matches);
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null) return;
+
+    const controller = createLemonsvilleScene(canvas, sceneState);
+    if (controller === null) {
+      setFallback(true);
+      return;
+    }
+
+    controllerRef.current = controller;
+    const resize = (): void => controller.resize(canvas.clientWidth, canvas.clientHeight);
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+    resize();
+
+    return () => {
+      observer.disconnect();
+      controller.dispose();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    controllerRef.current?.update(sceneState);
+  }, [sceneState]);
+
+  const description = `${environment.weather.kind.replaceAll("-", " ")} weather; ${environment.sentiment.kind.replaceAll("-", " ")} market sentiment; ${visibleSigns} advertising signs visible.`;
+
+  return (
+    <section className="stand-stage" aria-label="Lemonsville lemonade stand">
+      <canvas
+        ref={canvasRef}
+        className={fallback ? "scene-canvas scene-canvas-hidden" : "scene-canvas"}
+        role="img"
+        aria-label={description}
+      />
+      {fallback && (
+        <div className="scene-fallback" role="img" aria-label={description}>
+          <strong>Lemonsville</strong>
+          <span>{description}</span>
+        </div>
+      )}
+      <p className="scene-equivalent">{description}</p>
+    </section>
+  );
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
 import "./styles.css";
+import "./scene.css";
 
 const root = document.getElementById("root");
 if (root === null) {

--- a/apps/web/src/scene.css
+++ b/apps/web/src/scene.css
@@ -1,0 +1,33 @@
+.scene-canvas {
+  display: block;
+  width: 100%;
+  height: 310px;
+}
+
+.scene-canvas-hidden {
+  display: none;
+}
+
+.scene-fallback {
+  min-height: 310px;
+  display: grid;
+  place-content: center;
+  gap: 8px;
+  padding: 28px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, #7bc6d6 0 58%, #9cb976 58% 76%, #b99a71 76%);
+}
+
+.scene-fallback strong {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: clamp(1.6rem, 5vw, 3.2rem);
+}
+
+@media (max-width: 760px) {
+  .scene-canvas,
+  .scene-fallback {
+    height: 245px;
+    min-height: 245px;
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const typedSources = [
   "e2e/**/*.ts",
   "*.config.ts",
 ];
+const scopeTypedConfig = (config) => ({ ...config, files: typedSources });
 
 export default tseslint.config(
   {
@@ -14,12 +15,13 @@ export default tseslint.config(
       "build/**",
       "dist/**",
       "node_modules/**",
+      "public/**",
       "*.js",
       "legacy/**",
     ],
   },
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked.map(scopeTypedConfig),
+  ...tseslint.configs.stylisticTypeChecked.map(scopeTypedConfig),
   {
     files: typedSources,
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {
-    "@eslint/js": "^10.10.0",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.63.0",
     "@types/node": "^24.0.0",
     "eslint": "^10.10.0",

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "three": "^0.186.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.185.4"
   }
 }

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lemonade/scene",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "three": "^0.186.0"
+  }
+}

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -1,0 +1,223 @@
+import * as THREE from "three";
+
+export type SceneWeather = "sunny" | "cloudy" | "hot-and-dry" | "thunderstorm";
+export type CustomerActivity = "quiet" | "light" | "steady" | "lively" | "busy";
+export type ScenePhase = "deciding" | "report";
+
+export type LemonsvilleSceneState = Readonly<{
+  weather: SceneWeather;
+  customerActivity: CustomerActivity;
+  visibleSigns: number;
+  sellThroughBasisPoints: number;
+  phase: ScenePhase;
+  reducedMotion: boolean;
+}>;
+
+export interface LemonsvilleSceneController {
+  update(state: LemonsvilleSceneState): void;
+  resize(width: number, height: number): void;
+  dispose(): void;
+}
+
+const skyColor: Record<SceneWeather, number> = {
+  sunny: 0x79cbe0,
+  cloudy: 0xaabcc3,
+  "hot-and-dry": 0xe6b05f,
+  thunderstorm: 0x536471,
+};
+
+const customerCount: Record<CustomerActivity, number> = {
+  quiet: 1,
+  light: 3,
+  steady: 5,
+  lively: 8,
+  busy: 12,
+};
+
+const makeMaterial = (color: number): THREE.MeshStandardMaterial =>
+  new THREE.MeshStandardMaterial({ color, flatShading: true, roughness: 0.92 });
+
+const addBox = (
+  parent: THREE.Object3D,
+  size: readonly [number, number, number],
+  position: readonly [number, number, number],
+  color: number,
+): THREE.Mesh => {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), makeMaterial(color));
+  mesh.position.set(...position);
+  parent.add(mesh);
+  return mesh;
+};
+
+const createStand = (): THREE.Group => {
+  const stand = new THREE.Group();
+  addBox(stand, [4.5, 1.8, 1.7], [0, 0.9, 0], 0xe7c672);
+  addBox(stand, [4.9, 0.28, 2.05], [0, 2.18, 0], 0xf3d85d);
+  addBox(stand, [4.2, 0.8, 0.18], [0, 1.0, 0.94], 0xffefaf);
+  addBox(stand, [0.22, 2.4, 0.22], [-2.0, 2.9, 0], 0x5e4934);
+  addBox(stand, [0.22, 2.4, 0.22], [2.0, 2.9, 0], 0x5e4934);
+  addBox(stand, [4.8, 0.22, 2.0], [0, 4.0, 0], 0xe6a93b);
+  return stand;
+};
+
+const createHouse = (x: number, color: number, scale: number): THREE.Group => {
+  const house = new THREE.Group();
+  addBox(house, [3.4, 2.6, 2.4], [0, 1.3, 0], color);
+
+  const roof = new THREE.Mesh(
+    new THREE.ConeGeometry(2.75, 1.6, 4),
+    makeMaterial(0x7f4a43),
+  );
+  roof.rotation.y = Math.PI / 4;
+  roof.position.y = 3.25;
+  house.add(roof);
+
+  addBox(house, [0.75, 1.55, 0.15], [0, 0.8, 1.28], 0x486c69);
+  house.position.x = x;
+  house.position.z = -3.8;
+  house.scale.setScalar(scale);
+  return house;
+};
+
+const createTree = (x: number, z: number): THREE.Group => {
+  const tree = new THREE.Group();
+  const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.24, 1.5, 6), makeMaterial(0x765232));
+  trunk.position.y = 0.75;
+  tree.add(trunk);
+
+  const crown = new THREE.Mesh(new THREE.IcosahedronGeometry(1.05, 0), makeMaterial(0x5f8d56));
+  crown.position.y = 2.0;
+  tree.add(crown);
+  tree.position.set(x, 0, z);
+  return tree;
+};
+
+const createSign = (index: number): THREE.Group => {
+  const sign = new THREE.Group();
+  addBox(sign, [0.1, 0.85, 0.1], [0, 0.43, 0], 0x644c34);
+  addBox(sign, [0.95, 0.62, 0.12], [0, 1.05, 0], 0xf5d34c);
+  const side = index % 2 === 0 ? -1 : 1;
+  const row = Math.floor(index / 2);
+  sign.position.set(side * (3.6 + (row % 4) * 1.15), 0, 1.9 + Math.floor(row / 4) * 1.2);
+  sign.rotation.y = side * 0.18;
+  return sign;
+};
+
+const createCustomer = (index: number): THREE.Group => {
+  const customer = new THREE.Group();
+  const bodyColors = [0xd75c51, 0x507d83, 0xe0a43c, 0x7766a6] as const;
+  const color = bodyColors[index % bodyColors.length];
+  if (color === undefined) {
+    throw new Error("customer palette invariant failed");
+  }
+
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.24, 0.34, 1.0, 7), makeMaterial(color));
+  body.position.y = 0.55;
+  customer.add(body);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.25, 8, 6), makeMaterial(0xe1ad83));
+  head.position.y = 1.27;
+  customer.add(head);
+
+  const angle = (index / 12) * Math.PI * 1.15 + 0.35;
+  const radius = 4.1 + (index % 3) * 0.7;
+  customer.position.set(Math.cos(angle) * radius, 0, 2.5 + Math.sin(angle) * radius * 0.48);
+  customer.rotation.y = -angle;
+  return customer;
+};
+
+const disposeObject = (object: THREE.Object3D): void => {
+  if (!(object instanceof THREE.Mesh)) return;
+  object.geometry.dispose();
+  const materials = Array.isArray(object.material) ? object.material : [object.material];
+  for (const material of materials) material.dispose();
+};
+
+export const createLemonsvilleScene = (
+  canvas: HTMLCanvasElement,
+  initialState: LemonsvilleSceneState,
+): LemonsvilleSceneController | null => {
+  let renderer: THREE.WebGLRenderer;
+  try {
+    renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false, powerPreference: "high-performance" });
+  } catch {
+    return null;
+  }
+
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.shadowMap.enabled = false;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 100);
+  camera.position.set(0, 6.8, 13.5);
+  camera.lookAt(0, 1.7, 0);
+
+  scene.add(new THREE.HemisphereLight(0xfff2c6, 0x526b51, 2.0));
+  const sun = new THREE.DirectionalLight(0xfff0c9, 2.3);
+  sun.position.set(-5, 10, 7);
+  scene.add(sun);
+
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(30, 24), makeMaterial(0x92ad68));
+  ground.rotation.x = -Math.PI / 2;
+  ground.position.z = -1.5;
+  scene.add(ground);
+
+  const road = new THREE.Mesh(new THREE.PlaneGeometry(30, 4.0), makeMaterial(0xb2916e));
+  road.rotation.x = -Math.PI / 2;
+  road.position.set(0, 0.012, 4.1);
+  scene.add(road);
+
+  scene.add(createHouse(-7.2, 0xd56f52, 1.0));
+  scene.add(createHouse(7.0, 0xd4aa61, 0.9));
+  scene.add(createTree(-4.7, -2.9));
+  scene.add(createTree(4.9, -2.6));
+  scene.add(createTree(-8.2, 1.4));
+  scene.add(createTree(8.1, 1.0));
+  scene.add(createStand());
+
+  const signs = Array.from({ length: 25 }, (_, index) => createSign(index));
+  for (const sign of signs) scene.add(sign);
+
+  const customers = Array.from({ length: 12 }, (_, index) => createCustomer(index));
+  for (const customer of customers) scene.add(customer);
+
+  const render = (): void => renderer.render(scene, camera);
+
+  const update = (state: LemonsvilleSceneState): void => {
+    renderer.setClearColor(skyColor[state.weather], 1);
+
+    const signLimit = Math.max(0, Math.min(signs.length, Math.trunc(state.visibleSigns)));
+    signs.forEach((sign, index) => {
+      sign.visible = index < signLimit;
+    });
+
+    let visibleCustomers = customerCount[state.customerActivity];
+    if (state.phase === "report") {
+      const sellThroughBoost = Math.round((state.sellThroughBasisPoints / 10_000) * 3);
+      visibleCustomers = Math.min(customers.length, visibleCustomers + sellThroughBoost);
+    }
+    customers.forEach((customer, index) => {
+      customer.visible = index < visibleCustomers;
+    });
+
+    render();
+  };
+
+  const resize = (width: number, height: number): void => {
+    const safeWidth = Math.max(1, Math.floor(width));
+    const safeHeight = Math.max(1, Math.floor(height));
+    camera.aspect = safeWidth / safeHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(safeWidth, safeHeight, false);
+    render();
+  };
+
+  const dispose = (): void => {
+    scene.traverse(disposeObject);
+    renderer.dispose();
+  };
+
+  update(initialState);
+  return Object.freeze({ update, resize, dispose });
+};

--- a/packages/scene/tsconfig.build.json
+++ b/packages/scene/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/packages/scene/tsconfig.json
+++ b/packages/scene/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "@playwright/test";
 
+const isCI = Boolean(process.env["CI"]);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? "github" : "list",
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  reporter: isCI ? "github" : "list",
   use: {
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
@@ -13,6 +15,6 @@ export default defineConfig({
   webServer: {
     command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
   },
 });


### PR DESCRIPTION
## Outcome

Implements the first functional slice of #4 on top of the primary gameplay surface in #13.

Adds `@lemonade/scene`, a Three.js 0.186 presentation package that accepts only typed render state and renders a lightweight neighborhood scene containing:
- the lemonade stand and awning;
- houses, trees, road and ground plane;
- up to 25 visible advertising signs;
- five customer-activity bands represented with bounded customer geometry;
- distinct sunny, cloudy, hot/dry and thunderstorm sky states;
- report-phase sell-through emphasis;
- bounded DPR, explicit resize and disposal behavior.

The web adapter converts already-known simulation/UI state into scene state. The scene never imports `@lemonade/simulation` and cannot decide sales, pricing, costs or progression.

## Accessibility / fallback

The canvas has a gameplay-equivalent textual description. If WebGL renderer construction fails, the UI falls back to an accessible static/vector presentation. `prefers-reduced-motion` is passed explicitly into scene state for future animation work; this first renderer is update-driven and does not maintain a perpetual animation loop.

## Performance direction

- low-poly primitive geometry;
- no textures or remote runtime assets;
- no post-processing;
- no shadows;
- DPR capped at 2;
- rendering occurs on state/resize updates rather than continuously.

## Stack dependency

Base: `revival/primary-web-loop` / PR #13. The full stack remains draft until PR #11 receives a generated pnpm lockfile and CI can execute.

Advances #4; performance certification and animated weather/customer transitions remain follow-up work after executable CI exists.