### PR TITLE
feat(audio): add original procedural retro cue engine

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@lemonade/audio": "workspace:*",
     "@lemonade/scene": "workspace:*",
     "@lemonade/simulation": "workspace:*",
     "react": "^19.3.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 
+import { createProceduralAudioEngine, weatherCue } from "@lemonade/audio";
 import {
   createInitialState,
   createSeededRandom,
@@ -58,6 +59,7 @@ const decisionLimit = (state: GameState): Readonly<{ glasses: number; signs: num
 
 export const App = () => {
   const [random] = useState(() => createSeededRandom(seed(0x1e_ad_2026)));
+  const [audio] = useState(() => createProceduralAudioEngine());
   const [game, setGame] = useState<GameState>(() => createInitialState());
   const [environment, setEnvironment] = useState<DayEnvironment>(() =>
     generateEnvironment(dayNumber(1), random),
@@ -70,6 +72,26 @@ export const App = () => {
   const limits = useMemo(() => decisionLimit(game), [game]);
   const spend = glasses * Number(game.unitCost) + signs * Number(game.signCost);
   const affordable = spend <= Number(game.cash);
+
+  useEffect(() => {
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState === "hidden") {
+        void audio.suspend();
+      } else {
+        void audio.resume();
+      }
+    };
+    const onPageHide = (): void => {
+      void audio.dispose();
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("pagehide", onPageHide, { once: true });
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("pagehide", onPageHide);
+    };
+  }, [audio]);
 
   const sell = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
@@ -85,17 +107,29 @@ export const App = () => {
       environment,
     );
     setPhase(Object.freeze({ kind: "report", resolution }));
+
+    void audio.enable().then((enabled) => {
+      if (!enabled) return;
+      audio.play("day:submit");
+      const resultCue = Number(resolution.entry.net) >= 0 ? "day:profit" : "day:loss";
+      window.setTimeout(() => audio.play(resultCue), 220);
+    });
   };
 
   const planNextDay = (): void => {
     if (phase.kind !== "report") return;
 
     const nextState = phase.resolution.nextState;
+    const nextEnvironment = generateEnvironment(nextState.day, random);
     setGame(nextState);
-    setEnvironment(generateEnvironment(nextState.day, random));
+    setEnvironment(nextEnvironment);
     setGlasses((current) => Math.min(current, decisionLimit(nextState).glasses));
     setSigns((current) => Math.min(current, decisionLimit(nextState).signs));
     setPhase(Object.freeze({ kind: "deciding" }));
+
+    void audio.enable().then((enabled) => {
+      if (enabled) audio.play(weatherCue(nextEnvironment.weather.kind));
+    });
   };
 
   const sceneSigns =

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const typedSources = [
   "e2e/**/*.ts",
   "*.config.ts",
 ];
+const scopeTypedConfig = (config) => ({ ...config, files: typedSources });
 
 export default tseslint.config(
   {
@@ -14,12 +15,13 @@ export default tseslint.config(
       "build/**",
       "dist/**",
       "node_modules/**",
+      "public/**",
       "*.js",
       "legacy/**",
     ],
   },
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked.map(scopeTypedConfig),
+  ...tseslint.configs.stylisticTypeChecked.map(scopeTypedConfig),
   {
     files: typedSources,
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {
-    "@eslint/js": "^10.10.0",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.63.0",
     "@types/node": "^24.0.0",
     "eslint": "^10.10.0",

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@lemonade/audio",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json"
+  }
+}

--- a/packages/audio/src/index.ts
+++ b/packages/audio/src/index.ts
@@ -1,0 +1,182 @@
+export type AudioCue =
+  | "forecast:sunny"
+  | "forecast:cloudy"
+  | "forecast:hot-and-dry"
+  | "forecast:thunderstorm"
+  | "day:submit"
+  | "day:profit"
+  | "day:loss"
+  | "progression:unlock";
+
+export type ScheduledTone = Readonly<{
+  midiNote: number;
+  startSeconds: number;
+  durationSeconds: number;
+  gain: number;
+  waveform: OscillatorType;
+}>;
+
+export interface MusicalOutputAdapter {
+  play(cue: AudioCue, tones: readonly ScheduledTone[]): void | Promise<void>;
+  dispose(): void | Promise<void>;
+}
+
+export interface ProceduralAudioEngine {
+  enable(): Promise<boolean>;
+  play(cue: AudioCue): void;
+  setMuted(muted: boolean): void;
+  suspend(): Promise<void>;
+  resume(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+type MotifNote = Readonly<{
+  note: number;
+  beats: number;
+  waveform: OscillatorType;
+  gain?: number;
+}>;
+
+const MOTIFS: Record<AudioCue, readonly MotifNote[]> = {
+  "forecast:sunny": [
+    { note: 72, beats: 1, waveform: "triangle" },
+    { note: 76, beats: 1, waveform: "triangle" },
+    { note: 79, beats: 2, waveform: "triangle" },
+  ],
+  "forecast:cloudy": [
+    { note: 67, beats: 1, waveform: "sine" },
+    { note: 70, beats: 1, waveform: "sine" },
+    { note: 65, beats: 2, waveform: "sine" },
+  ],
+  "forecast:hot-and-dry": [
+    { note: 76, beats: 1, waveform: "square", gain: 0.055 },
+    { note: 79, beats: 1, waveform: "square", gain: 0.055 },
+    { note: 83, beats: 2, waveform: "square", gain: 0.055 },
+  ],
+  "forecast:thunderstorm": [
+    { note: 48, beats: 1, waveform: "sawtooth", gain: 0.045 },
+    { note: 43, beats: 2, waveform: "sawtooth", gain: 0.045 },
+  ],
+  "day:submit": [
+    { note: 60, beats: 0.5, waveform: "square", gain: 0.05 },
+    { note: 67, beats: 0.75, waveform: "square", gain: 0.05 },
+  ],
+  "day:profit": [
+    { note: 64, beats: 0.75, waveform: "triangle" },
+    { note: 67, beats: 0.75, waveform: "triangle" },
+    { note: 72, beats: 0.75, waveform: "triangle" },
+    { note: 76, beats: 1.5, waveform: "triangle" },
+  ],
+  "day:loss": [
+    { note: 60, beats: 0.75, waveform: "sine" },
+    { note: 57, beats: 0.75, waveform: "sine" },
+    { note: 53, beats: 1.5, waveform: "sine" },
+  ],
+  "progression:unlock": [
+    { note: 60, beats: 0.5, waveform: "square", gain: 0.045 },
+    { note: 64, beats: 0.5, waveform: "square", gain: 0.045 },
+    { note: 67, beats: 0.5, waveform: "square", gain: 0.045 },
+    { note: 72, beats: 1.5, waveform: "square", gain: 0.045 },
+  ],
+};
+
+const BEAT_SECONDS = 0.12;
+const GAP_SECONDS = 0.018;
+
+export const compileCue = (cue: AudioCue): readonly ScheduledTone[] => {
+  let cursor = 0;
+  const tones: ScheduledTone[] = [];
+
+  for (const motifNote of MOTIFS[cue]) {
+    const durationSeconds = motifNote.beats * BEAT_SECONDS;
+    tones.push(
+      Object.freeze({
+        midiNote: motifNote.note,
+        startSeconds: cursor,
+        durationSeconds,
+        gain: motifNote.gain ?? 0.07,
+        waveform: motifNote.waveform,
+      }),
+    );
+    cursor += durationSeconds + GAP_SECONDS;
+  }
+
+  return Object.freeze(tones);
+};
+
+const midiToFrequency = (note: number): number => 440 * 2 ** ((note - 69) / 12);
+
+export const createProceduralAudioEngine = (): ProceduralAudioEngine => {
+  let context: AudioContext | null = null;
+  let muted = false;
+  let disposed = false;
+
+  const enable = async (): Promise<boolean> => {
+    if (disposed) return false;
+
+    if (context === null) {
+      try {
+        context = new AudioContext({ latencyHint: "interactive" });
+      } catch {
+        return false;
+      }
+    }
+
+    if (context.state === "suspended") {
+      await context.resume();
+    }
+    return context.state === "running";
+  };
+
+  const play = (cue: AudioCue): void => {
+    const activeContext = context;
+    if (muted || disposed || activeContext === null || activeContext.state === "closed") return;
+
+    const baseTime = activeContext.currentTime + 0.012;
+    for (const tone of compileCue(cue)) {
+      const oscillator = activeContext.createOscillator();
+      const envelope = activeContext.createGain();
+      const start = baseTime + tone.startSeconds;
+      const end = start + tone.durationSeconds;
+
+      oscillator.type = tone.waveform;
+      oscillator.frequency.setValueAtTime(midiToFrequency(tone.midiNote), start);
+      envelope.gain.setValueAtTime(0.0001, start);
+      envelope.gain.exponentialRampToValueAtTime(tone.gain, start + Math.min(0.018, tone.durationSeconds / 3));
+      envelope.gain.exponentialRampToValueAtTime(0.0001, end);
+
+      oscillator.connect(envelope);
+      envelope.connect(activeContext.destination);
+      oscillator.addEventListener("ended", () => {
+        oscillator.disconnect();
+        envelope.disconnect();
+      });
+      oscillator.start(start);
+      oscillator.stop(end + 0.004);
+    }
+  };
+
+  const setMuted = (value: boolean): void => {
+    muted = value;
+  };
+
+  const suspend = async (): Promise<void> => {
+    if (context !== null && context.state === "running") await context.suspend();
+  };
+
+  const resume = async (): Promise<void> => {
+    if (!disposed && context !== null && context.state === "suspended") await context.resume();
+  };
+
+  const dispose = async (): Promise<void> => {
+    disposed = true;
+    if (context !== null && context.state !== "closed") await context.close();
+    context = null;
+  };
+
+  return Object.freeze({ enable, play, setMuted, suspend, resume, dispose });
+};
+
+export const weatherCue = (
+  weather: "sunny" | "cloudy" | "hot-and-dry" | "thunderstorm",
+): AudioCue => `forecast:${weather}`;

--- a/packages/audio/test/audio.test.ts
+++ b/packages/audio/test/audio.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { compileCue, type AudioCue } from "../src/index.js";
+
+const cues: readonly AudioCue[] = [
+  "forecast:sunny",
+  "forecast:cloudy",
+  "forecast:hot-and-dry",
+  "forecast:thunderstorm",
+  "day:submit",
+  "day:profit",
+  "day:loss",
+  "progression:unlock",
+];
+
+describe("procedural cue compiler", () => {
+  it("is deterministic without an audio device", () => {
+    for (const cue of cues) {
+      expect(compileCue(cue)).toEqual(compileCue(cue));
+    }
+  });
+
+  it("produces bounded playable events for every semantic cue", () => {
+    for (const cue of cues) {
+      const tones = compileCue(cue);
+      expect(tones.length).toBeGreaterThan(0);
+
+      for (const tone of tones) {
+        expect(tone.midiNote).toBeGreaterThanOrEqual(0);
+        expect(tone.midiNote).toBeLessThanOrEqual(127);
+        expect(tone.startSeconds).toBeGreaterThanOrEqual(0);
+        expect(tone.durationSeconds).toBeGreaterThan(0);
+        expect(tone.gain).toBeGreaterThan(0);
+        expect(tone.gain).toBeLessThanOrEqual(0.1);
+      }
+    }
+  });
+
+  it("schedules tones monotonically within a cue", () => {
+    for (const cue of cues) {
+      let previousStart = -1;
+      for (const tone of compileCue(cue)) {
+        expect(tone.startSeconds).toBeGreaterThan(previousStart);
+        previousStart = tone.startSeconds;
+      }
+    }
+  });
+});

--- a/packages/audio/tsconfig.build.json
+++ b/packages/audio/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["test/**/*.ts"]
+}

--- a/packages/audio/tsconfig.json
+++ b/packages/audio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "three": "^0.186.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.185.4"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "@playwright/test";
 
+const isCI = Boolean(process.env["CI"]);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? "github" : "list",
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  reporter: isCI ? "github" : "list",
   use: {
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
@@ -13,6 +15,6 @@ export default defineConfig({
   webServer: {
     command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
   },
 });


### PR DESCRIPTION
## Outcome

Advances #5 with a browser-first procedural audio package stacked on the typed 3D scene PR #14.

Adds `@lemonade/audio` with:
- semantic cues for weather, submit, profit/loss and progression;
- original short motifs represented as immutable typed note plans;
- a deterministic pure cue compiler that can be tested without an audio device;
- a lazy Web Audio oscillator/envelope engine that unlocks only after an existing gameplay gesture;
- suspend/resume handling for page visibility and explicit disposal;
- a `MusicalOutputAdapter` boundary for future MIDI/SoundFont/native implementations without coupling them to simulation or UI state.

The web app enables audio from the existing Sell / next-day gestures. Audio failure, muting, scheduling or device state cannot affect simulation results.

## Validation design

Unit tests cover every semantic cue without requiring an AudioContext: deterministic compilation, valid MIDI note bounds, bounded gains/durations and monotonic scheduling.

## Stack dependency

Base: `revival/vector-3d-scene` / PR #14. The stack remains draft until PR #11 receives a real generated pnpm lockfile and CI can execute.

## Deliberately deferred

- user-facing master/music/SFX preferences;
- Web MIDI discovery/output;
- native SoundFont/system-MIDI adapter;
- browser lifecycle acceptance tests after executable CI is available.

Those are separate adapter/polish work and do not block the procedural core.