### PR TITLE
feat(ui): add accessible ledger history and business charts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@lemonade/audio": "workspace:*",
     "@lemonade/scene": "workspace:*",
     "@lemonade/simulation": "workspace:*",
+    "@lemonade/ui": "workspace:*",
     "react": "^19.3.0",
     "react-dom": "^19.3.0"
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import {
   type DayResolution,
   type GameState,
 } from "@lemonade/simulation";
+import { LedgerHistory } from "@lemonade/ui";
 
 import { LemonsvilleScene } from "./LemonsvilleScene.js";
 
@@ -137,6 +138,8 @@ export const App = () => {
   const sceneSold = phase.kind === "report" ? Number(phase.resolution.entry.sold) : 0;
   const scenePrepared =
     phase.kind === "report" ? Number(phase.resolution.entry.decision.glasses) : glasses;
+  const historyEntries =
+    phase.kind === "report" ? phase.resolution.nextState.ledger : game.ledger;
 
   return (
     <main className="game-shell">
@@ -302,6 +305,8 @@ export const App = () => {
           </button>
         </section>
       )}
+
+      <LedgerHistory entries={historyEntries} />
     </main>
   );
 };

--- a/apps/web/src/history.css
+++ b/apps/web/src/history.css
@@ -1,0 +1,145 @@
+.ledger-history {
+  margin-top: 22px;
+  padding: clamp(18px, 4vw, 34px);
+  border: 2px solid #211d14;
+  background: #fff9e4;
+  box-shadow: 8px 8px 0 #211d14;
+}
+
+.history-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.chart-card {
+  margin: 0;
+  padding: 16px;
+  border: 2px solid #211d14;
+  background: #f6df8f;
+}
+
+.chart-card figcaption {
+  margin-bottom: 10px;
+  font-weight: 800;
+}
+
+.history-chart {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.chart-axis {
+  stroke: #6e654e;
+  stroke-width: 2;
+}
+
+.chart-line {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 4;
+  vector-effect: non-scaling-stroke;
+}
+
+.chart-cash,
+.chart-sold {
+  color: #236f5e;
+}
+
+.chart-prepared {
+  color: #a9631a;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 8px;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chart-legend i {
+  width: 18px;
+  height: 4px;
+  background: currentColor;
+}
+
+.legend-prepared {
+  color: #a9631a;
+}
+
+.legend-sold {
+  color: #236f5e;
+}
+
+.history-table-wrap {
+  overflow-x: auto;
+  margin-top: 18px;
+  border: 2px solid #211d14;
+}
+
+.history-table {
+  width: 100%;
+  min-width: 720px;
+  border-collapse: collapse;
+  background: #fffdf3;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-table caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.history-table th,
+.history-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #d9cda9;
+  text-align: right;
+}
+
+.history-table th:first-child,
+.history-table td:first-child {
+  text-align: left;
+}
+
+.history-table thead th {
+  background: #f7cf52;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 760px) {
+  .history-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .chart-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App.js";
 import "./styles.css";
 import "./scene.css";
+import "./history.css";
 
 const root = document.getElementById("root");
 if (root === null) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const typedSources = [
   "e2e/**/*.ts",
   "*.config.ts",
 ];
+const scopeTypedConfig = (config) => ({ ...config, files: typedSources });
 
 export default tseslint.config(
   {
@@ -14,12 +15,13 @@ export default tseslint.config(
       "build/**",
       "dist/**",
       "node_modules/**",
+      "public/**",
       "*.js",
       "legacy/**",
     ],
   },
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked.map(scopeTypedConfig),
+  ...tseslint.configs.stylisticTypeChecked.map(scopeTypedConfig),
   {
     files: typedSources,
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {
-    "@eslint/js": "^10.10.0",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.63.0",
     "@types/node": "^24.0.0",
     "eslint": "^10.10.0",

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "three": "^0.186.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.185.4"
   }
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,5 @@
+# @lemonade/ui
+
+Presentation-only UI primitives that project immutable simulation data without recalculating game rules.
+
+The package may depend on `@lemonade/simulation` types and historical records, but it must not derive authoritative demand, costs, taxes, progression, or other simulation outcomes.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@lemonade/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@lemonade/simulation": "workspace:*",
+    "react": "^19.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.3.0"
+  }
+}

--- a/packages/ui/src/LedgerHistory.tsx
+++ b/packages/ui/src/LedgerHistory.tsx
@@ -1,0 +1,159 @@
+import type { DailyLedgerEntry } from "@lemonade/simulation";
+
+import { projectLedger, sellThroughBasisPoints, type LedgerPoint } from "./ledger.js";
+
+const CHART_WIDTH = 720;
+const CHART_HEIGHT = 180;
+const CHART_PADDING = 18;
+
+const moneyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+});
+
+const formatMoney = (cents: number): string => moneyFormatter.format(cents / 100);
+
+const seriesPoints = (
+  values: readonly number[],
+  minValue: number,
+  maxValue: number,
+): string => {
+  if (values.length === 0) return "";
+
+  const usableWidth = CHART_WIDTH - CHART_PADDING * 2;
+  const usableHeight = CHART_HEIGHT - CHART_PADDING * 2;
+  const span = Math.max(1, maxValue - minValue);
+  const denominator = Math.max(1, values.length - 1);
+
+  return values
+    .map((value, index) => {
+      const x = CHART_PADDING + (index / denominator) * usableWidth;
+      const y = CHART_PADDING + (1 - (value - minValue) / span) * usableHeight;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+};
+
+const cashTrend = (points: readonly LedgerPoint[]): string => {
+  const values = points.map((point) => point.endingCashCents);
+  if (values.length === 0) return "";
+  return seriesPoints(values, Math.min(...values), Math.max(...values));
+};
+
+const inventoryTrends = (
+  points: readonly LedgerPoint[],
+): Readonly<{ prepared: string; sold: string }> => {
+  const prepared = points.map((point) => point.prepared);
+  const sold = points.map((point) => point.sold);
+  const maximum = Math.max(1, ...prepared, ...sold);
+  return Object.freeze({
+    prepared: seriesPoints(prepared, 0, maximum),
+    sold: seriesPoints(sold, 0, maximum),
+  });
+};
+
+export type LedgerHistoryProps = Readonly<{
+  entries: readonly DailyLedgerEntry[];
+}>;
+
+export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
+  const points = projectLedger(entries);
+  if (points.length === 0) return null;
+
+  const cash = cashTrend(points);
+  const inventory = inventoryTrends(points);
+  const latest = points.at(-1);
+  if (latest === undefined) return null;
+
+  return (
+    <section className="ledger-history" aria-labelledby="ledger-history-title">
+      <header className="history-heading">
+        <div>
+          <p className="eyebrow">Business memory</p>
+          <h2 id="ledger-history-title">Sales history</h2>
+        </div>
+        <p>
+          Latest sell-through <strong>{(sellThroughBasisPoints(latest) / 100).toFixed(0)}%</strong>
+        </p>
+      </header>
+
+      <div className="chart-grid">
+        <figure className="chart-card">
+          <figcaption>Cash over time</figcaption>
+          <svg
+            className="history-chart"
+            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+            role="img"
+            aria-label={`Cash history from ${formatMoney(points[0]?.endingCashCents ?? 0)} to ${formatMoney(latest.endingCashCents)}`}
+          >
+            <line
+              className="chart-axis"
+              x1={CHART_PADDING}
+              y1={CHART_HEIGHT - CHART_PADDING}
+              x2={CHART_WIDTH - CHART_PADDING}
+              y2={CHART_HEIGHT - CHART_PADDING}
+            />
+            <polyline className="chart-line chart-cash" points={cash} />
+          </svg>
+        </figure>
+
+        <figure className="chart-card">
+          <figcaption>Prepared vs sold</figcaption>
+          <svg
+            className="history-chart"
+            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+            role="img"
+            aria-label={`Inventory history across ${points.length} day${points.length === 1 ? "" : "s"}`}
+          >
+            <line
+              className="chart-axis"
+              x1={CHART_PADDING}
+              y1={CHART_HEIGHT - CHART_PADDING}
+              x2={CHART_WIDTH - CHART_PADDING}
+              y2={CHART_HEIGHT - CHART_PADDING}
+            />
+            <polyline className="chart-line chart-prepared" points={inventory.prepared} />
+            <polyline className="chart-line chart-sold" points={inventory.sold} />
+          </svg>
+          <div className="chart-legend" aria-hidden="true">
+            <span><i className="legend-prepared" />Prepared</span>
+            <span><i className="legend-sold" />Sold</span>
+          </div>
+        </figure>
+      </div>
+
+      <div className="history-table-wrap">
+        <table className="history-table">
+          <caption>Complete values represented by the sales-history charts</caption>
+          <thead>
+            <tr>
+              <th scope="col">Day</th>
+              <th scope="col">Prepared</th>
+              <th scope="col">Sold</th>
+              <th scope="col">Price</th>
+              <th scope="col">Revenue</th>
+              <th scope="col">Expenses</th>
+              <th scope="col">Net</th>
+              <th scope="col">Cash</th>
+            </tr>
+          </thead>
+          <tbody>
+            {points.map((point) => (
+              <tr key={point.day}>
+                <th scope="row">{point.day}</th>
+                <td>{point.prepared}</td>
+                <td>{point.sold}</td>
+                <td>{formatMoney(point.priceCents)}</td>
+                <td>{formatMoney(point.revenueCents)}</td>
+                <td>{formatMoney(point.expensesCents)}</td>
+                <td>{point.netCents >= 0 ? "+" : "−"}{formatMoney(Math.abs(point.netCents))}</td>
+                <td>{formatMoney(point.endingCashCents)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,6 @@
+export { LedgerHistory, type LedgerHistoryProps } from "./LedgerHistory.js";
+export {
+  projectLedger,
+  sellThroughBasisPoints,
+  type LedgerPoint,
+} from "./ledger.js";

--- a/packages/ui/src/ledger.ts
+++ b/packages/ui/src/ledger.ts
@@ -1,0 +1,33 @@
+import type { DailyLedgerEntry } from "@lemonade/simulation";
+
+export type LedgerPoint = Readonly<{
+  day: number;
+  prepared: number;
+  sold: number;
+  priceCents: number;
+  revenueCents: number;
+  expensesCents: number;
+  netCents: number;
+  endingCashCents: number;
+}>;
+
+export const projectLedger = (
+  entries: readonly DailyLedgerEntry[],
+): readonly LedgerPoint[] =>
+  Object.freeze(
+    entries.map((entry) =>
+      Object.freeze({
+        day: Number(entry.day),
+        prepared: Number(entry.decision.glasses),
+        sold: Number(entry.sold),
+        priceCents: Number(entry.decision.price),
+        revenueCents: Number(entry.revenue),
+        expensesCents: Number(entry.expenses),
+        netCents: Number(entry.net),
+        endingCashCents: Number(entry.endingCash),
+      }),
+    ),
+  );
+
+export const sellThroughBasisPoints = (point: LedgerPoint): number =>
+  point.prepared === 0 ? 0 : Math.round((point.sold / point.prepared) * 10_000);

--- a/packages/ui/test/ledger.test.ts
+++ b/packages/ui/test/ledger.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  basisPoints,
+  dayNumber,
+  glassCount,
+  moneyCents,
+  signCount,
+  signedMoneyCents,
+  type DailyLedgerEntry,
+} from "@lemonade/simulation";
+
+import { projectLedger, sellThroughBasisPoints } from "../src/ledger.js";
+
+const entry = (day: number, prepared: number, sold: number): DailyLedgerEntry =>
+  Object.freeze({
+    day: dayNumber(day),
+    decision: Object.freeze({
+      glasses: glassCount(prepared),
+      signs: signCount(1),
+      price: moneyCents(10),
+    }),
+    environment: Object.freeze({
+      weather: Object.freeze({ kind: "sunny", demandMultiplier: basisPoints(10_000) }),
+      sentiment: Object.freeze({ kind: "neutral", demandMultiplier: basisPoints(10_000) }),
+      event: Object.freeze({ kind: "none", demandMultiplier: basisPoints(10_000) }),
+    }),
+    potentialDemand: glassCount(sold),
+    sold: glassCount(sold),
+    revenue: moneyCents(sold * 10),
+    expenses: moneyCents(prepared * 2 + 15),
+    net: signedMoneyCents(sold * 10 - (prepared * 2 + 15)),
+    endingCash: moneyCents(200 + sold * 10 - (prepared * 2 + 15)),
+    lines: Object.freeze([]),
+  });
+
+describe("ledger projection", () => {
+  it("projects immutable historical values without recomputing them", () => {
+    const points = projectLedger([entry(1, 20, 15), entry(2, 24, 24)]);
+
+    expect(points).toEqual([
+      expect.objectContaining({ day: 1, prepared: 20, sold: 15, priceCents: 10 }),
+      expect.objectContaining({ day: 2, prepared: 24, sold: 24, priceCents: 10 }),
+    ]);
+    expect(Object.isFrozen(points)).toBe(true);
+    expect(Object.isFrozen(points[0])).toBe(true);
+  });
+
+  it("reports sell-through in basis points and handles zero inventory", () => {
+    expect(sellThroughBasisPoints(projectLedger([entry(1, 20, 15)])[0]!)).toBe(7_500);
+    expect(sellThroughBasisPoints(projectLedger([entry(1, 0, 0)])[0]!)).toBe(0);
+  });
+});

--- a/packages/ui/test/ledger.test.ts
+++ b/packages/ui/test/ledger.test.ts
@@ -34,6 +34,12 @@ const entry = (day: number, prepared: number, sold: number): DailyLedgerEntry =>
     lines: Object.freeze([]),
   });
 
+const onlyPoint = (value: readonly DailyLedgerEntry[]) => {
+  const point = projectLedger(value).at(0);
+  if (point === undefined) throw new Error("expected one ledger point");
+  return point;
+};
+
 describe("ledger projection", () => {
   it("projects immutable historical values without recomputing them", () => {
     const points = projectLedger([entry(1, 20, 15), entry(2, 24, 24)]);
@@ -43,11 +49,11 @@ describe("ledger projection", () => {
       expect.objectContaining({ day: 2, prepared: 24, sold: 24, priceCents: 10 }),
     ]);
     expect(Object.isFrozen(points)).toBe(true);
-    expect(Object.isFrozen(points[0])).toBe(true);
+    expect(Object.isFrozen(points.at(0))).toBe(true);
   });
 
   it("reports sell-through in basis points and handles zero inventory", () => {
-    expect(sellThroughBasisPoints(projectLedger([entry(1, 20, 15)])[0]!)).toBe(7_500);
-    expect(sellThroughBasisPoints(projectLedger([entry(1, 0, 0)])[0]!)).toBe(0);
+    expect(sellThroughBasisPoints(onlyPoint([entry(1, 20, 15)]))).toBe(7_500);
+    expect(sellThroughBasisPoints(onlyPoint([entry(1, 0, 0)]))).toBe(0);
   });
 });

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["test/**/*.ts", "test/**/*.tsx"]
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "@playwright/test";
 
+const isCI = Boolean(process.env["CI"]);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? "github" : "list",
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  reporter: isCI ? "github" : "list",
   use: {
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
@@ -13,6 +15,6 @@ export default defineConfig({
   webServer: {
     command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
   },
 });


### PR DESCRIPTION
## Outcome

Implements #6 as a presentation-only analytical layer stacked on procedural-audio PR #15.

Adds `@lemonade/ui` with:
- immutable projection of historical `DailyLedgerEntry` values;
- sell-through calculations that never recompute authoritative simulation rules;
- dependency-light SVG charts for cash over time and prepared-vs-sold inventory;
- complete semantic table equivalents for every charted value;
- strict unit tests for projection immutability and sell-through behavior.

The web app surfaces the current report immediately from `resolution.nextState.ledger`, so the just-completed day appears in business history before the player advances to the next forecast.

## Architecture

`@lemonade/ui` may consume simulation records and types but cannot calculate demand, accounting obligations, progression, taxes or other authoritative outcomes. Historical values are rendered exactly as stored in the immutable ledger.

## Accessibility

- charts have descriptive `aria-label` text;
- every quantitative chart has a semantic table equivalent;
- history tables retain horizontal scrolling on small viewports rather than collapsing values;
- no chart interaction is required to access data.

## Stack dependency

Base: `revival/procedural-audio` / PR #15. The full stack remains draft until PR #11 receives a generated `pnpm-lock.yaml` and CI can execute the workspace.

Closes #6 when validated and merged through the stack.