### PR TITLE
feat(simulation): introduce progressive finance obligations and credit

### DIFF
--- a/.github/workflows/stack-validation.yml
+++ b/.github/workflows/stack-validation.yml
@@ -1,0 +1,29 @@
+name: stack validation
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 12.4.0
+          run_install: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Install workspace without persisting generated lockfile
+        run: pnpm install --no-frozen-lockfile
+      - name: Typecheck lint unit test and build
+        run: pnpm check
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run browser acceptance tests
+        run: pnpm test:e2e

--- a/.github/workflows/stack-validation.yml
+++ b/.github/workflows/stack-validation.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install workspace without persisting generated lockfile
         run: pnpm install --no-frozen-lockfile
       - name: Typecheck lint unit test and build

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: {},
+};

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,12 +2,15 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 
 import { createProceduralAudioEngine, weatherCue } from "@lemonade/audio";
 import {
+  availableOperatingFunds,
   createInitialState,
   createSeededRandom,
   dayNumber,
+  financeRulesForTier,
   generateEnvironment,
   glassCount,
   moneyCents,
+  predictableFixedObligations,
   seed,
   signCount,
   simulateDay,
@@ -52,11 +55,43 @@ const moneyFormatter = new Intl.NumberFormat("en-US", {
 
 const formatMoney = (cents: number): string => moneyFormatter.format(cents / 100);
 
-const decisionLimit = (state: GameState): Readonly<{ glasses: number; signs: number }> =>
-  Object.freeze({
-    glasses: Math.min(250, Math.floor(Number(state.cash) / Number(state.unitCost))),
-    signs: Math.min(25, Math.floor(Number(state.cash) / Number(state.signCost))),
+const decisionBudget = (state: GameState): number =>
+  Math.max(
+    0,
+    Number(availableOperatingFunds(state)) - Number(predictableFixedObligations(state)),
+  );
+
+const decisionLimit = (state: GameState): Readonly<{ glasses: number; signs: number }> => {
+  const budget = decisionBudget(state);
+  return Object.freeze({
+    glasses: Math.min(250, Math.floor(budget / Number(state.unitCost))),
+    signs: Math.min(25, Math.floor(budget / Number(state.signCost))),
   });
+};
+
+const financeSummary = (state: GameState): string => {
+  const rules = financeRulesForTier(state.tier);
+  const parts: string[] = [];
+
+  if (Number(rules.supplierFee) > 0) {
+    parts.push(`${formatMoney(Number(rules.supplierFee))} supplier fee`);
+  }
+  if (Number(rules.taxRate) > 0) {
+    parts.push(`${(Number(rules.taxRate) / 100).toFixed(1)}% positive-profit tax`);
+  }
+  if (Number(rules.bankFee) > 0) {
+    parts.push(`${formatMoney(Number(rules.bankFee))} bank fee`);
+  }
+  if (Number(rules.creditLimit) > 0) {
+    parts.push(`${formatMoney(Number(rules.creditLimit))} working-capital limit`);
+    parts.push(`${(Number(rules.loanInterestRate) / 100).toFixed(2)}% daily loan interest`);
+    parts.push(`${(Number(rules.savingsInterestRate) / 100).toFixed(2)}% daily cash interest`);
+  }
+
+  return parts.length === 0
+    ? "Classic neighborhood rules — no added finance obligations."
+    : parts.join(" · ");
+};
 
 export const App = () => {
   const [random] = useState(() => createSeededRandom(seed(0x1e_ad_2026)));
@@ -71,8 +106,11 @@ export const App = () => {
   const [price, setPrice] = useState(10);
 
   const limits = useMemo(() => decisionLimit(game), [game]);
-  const spend = glasses * Number(game.unitCost) + signs * Number(game.signCost);
-  const affordable = spend <= Number(game.cash);
+  const fixedObligations = Number(predictableFixedObligations(game));
+  const operatingFunds = Number(availableOperatingFunds(game));
+  const spend =
+    glasses * Number(game.unitCost) + signs * Number(game.signCost) + fixedObligations;
+  const affordable = spend <= operatingFunds;
 
   useEffect(() => {
     const onVisibilityChange = (): void => {
@@ -114,6 +152,9 @@ export const App = () => {
       audio.play("day:submit");
       const resultCue = Number(resolution.entry.net) >= 0 ? "day:profit" : "day:loss";
       window.setTimeout(() => audio.play(resultCue), 220);
+      if (resolution.nextState.tier !== game.tier) {
+        window.setTimeout(() => audio.play("progression:unlock"), 520);
+      }
     });
   };
 
@@ -157,6 +198,12 @@ export const App = () => {
             <dt>Cash</dt>
             <dd>{formatMoney(Number(game.cash))}</dd>
           </div>
+          {(game.tier >= 3 || Number(game.loanBalance) > 0) && (
+            <div>
+              <dt>Debt</dt>
+              <dd>{formatMoney(Number(game.loanBalance))}</dd>
+            </div>
+          )}
         </dl>
       </header>
 
@@ -181,6 +228,11 @@ export const App = () => {
         </div>
       </section>
 
+      <aside className="obligation-strip" aria-label="Business finance rules">
+        <strong>Business tier {game.tier}</strong>
+        <span>{financeSummary(game)}</span>
+      </aside>
+
       <LemonsvilleScene
         environment={environment}
         visibleSigns={sceneSigns}
@@ -197,7 +249,7 @@ export const App = () => {
               <h2>Three decisions. Then sell.</h2>
             </div>
             <p className={affordable ? "spend" : "spend spend-warning"}>
-              Spend {formatMoney(spend)} of {formatMoney(Number(game.cash))}
+              Spend {formatMoney(spend)} of {formatMoney(operatingFunds)} operating funds
             </p>
           </header>
 
@@ -257,7 +309,7 @@ export const App = () => {
 
           {!affordable && (
             <p className="inline-error" role="alert">
-              This plan costs more cash than the stand has. Reduce glasses or signs.
+              This plan exceeds available cash and credit. Reduce glasses or signs.
             </p>
           )}
 
@@ -282,7 +334,7 @@ export const App = () => {
 
           <dl className="results-grid">
             <div>
-              <dt>Revenue</dt>
+              <dt>Sales</dt>
               <dd>{formatMoney(Number(phase.resolution.entry.revenue))}</dd>
             </div>
             <div>
@@ -294,12 +346,35 @@ export const App = () => {
               <dd>{formatMoney(Number(phase.resolution.entry.endingCash))}</dd>
             </div>
             <div>
-              <dt>Potential demand</dt>
-              <dd>{Number(phase.resolution.entry.potentialDemand)}</dd>
+              <dt>Ending debt</dt>
+              <dd>{formatMoney(Number(phase.resolution.entry.endingLoanBalance))}</dd>
             </div>
           </dl>
 
+          <div className="ledger-breakdown">
+            <h3>Day ledger</h3>
+            <table>
+              <caption>Credits, operating expenses and financing movements for this day</caption>
+              <tbody>
+                {phase.resolution.entry.lines.map((line, index) => (
+                  <tr key={`${line.kind}-${index}`}>
+                    <th scope="row">{line.label}</th>
+                    <td className={line.direction === "credit" ? "ledger-credit" : "ledger-debit"}>
+                      {line.direction === "credit" ? "+" : "−"}
+                      {formatMoney(Number(line.amount))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
           <p className="event-note">{eventLabel[phase.resolution.entry.environment.event.kind]}</p>
+          {phase.resolution.nextState.tier !== game.tier && (
+            <p className="progression-note">
+              Tier {phase.resolution.nextState.tier} unlocks tomorrow. New finance rules will be shown before you sell.
+            </p>
+          )}
           <button className="next-button" type="button" onClick={planNextDay}>
             Plan next day
           </button>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type SyntheticEvent } from "react";
 
 import { createProceduralAudioEngine, weatherCue } from "@lemonade/audio";
 import {
@@ -132,7 +132,7 @@ export const App = () => {
     };
   }, [audio]);
 
-  const sell = (event: FormEvent<HTMLFormElement>): void => {
+  const sell = (event: SyntheticEvent<HTMLFormElement>): void => {
     event.preventDefault();
     if (!affordable || phase.kind !== "deciding") return;
 
@@ -151,9 +151,13 @@ export const App = () => {
       if (!enabled) return;
       audio.play("day:submit");
       const resultCue = Number(resolution.entry.net) >= 0 ? "day:profit" : "day:loss";
-      window.setTimeout(() => audio.play(resultCue), 220);
+      window.setTimeout(() => {
+        audio.play(resultCue);
+      }, 220);
       if (resolution.nextState.tier !== game.tier) {
-        window.setTimeout(() => audio.play("progression:unlock"), 520);
+        window.setTimeout(() => {
+          audio.play("progression:unlock");
+        }, 520);
       }
     });
   };
@@ -267,7 +271,9 @@ export const App = () => {
               max={limits.glasses}
               step="1"
               value={glasses}
-              onChange={(event) => setGlasses(event.currentTarget.valueAsNumber)}
+              onChange={(event) => {
+                setGlasses(event.currentTarget.valueAsNumber);
+              }}
             />
           </label>
 
@@ -285,7 +291,9 @@ export const App = () => {
               max={limits.signs}
               step="1"
               value={signs}
-              onChange={(event) => setSigns(event.currentTarget.valueAsNumber)}
+              onChange={(event) => {
+                setSigns(event.currentTarget.valueAsNumber);
+              }}
             />
           </label>
 
@@ -303,7 +311,9 @@ export const App = () => {
               max="100"
               step="1"
               value={price}
-              onChange={(event) => setPrice(event.currentTarget.valueAsNumber)}
+              onChange={(event) => {
+                setPrice(event.currentTarget.valueAsNumber);
+              }}
             />
           </label>
 
@@ -357,7 +367,7 @@ export const App = () => {
               <caption>Credits, operating expenses and financing movements for this day</caption>
               <tbody>
                 {phase.resolution.entry.lines.map((line, index) => (
-                  <tr key={`${line.kind}-${index}`}>
+                  <tr key={`${line.kind}-${String(index)}`}>
                     <th scope="row">{line.label}</th>
                     <td className={line.direction === "credit" ? "ledger-credit" : "ledger-debit"}>
                       {line.direction === "credit" ? "+" : "−"}

--- a/apps/web/src/LemonsvilleScene.tsx
+++ b/apps/web/src/LemonsvilleScene.tsx
@@ -54,9 +54,13 @@ export const LemonsvilleScene = ({
 
   useEffect(() => {
     const media = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const onChange = (): void => setReducedMotion(media.matches);
+    const onChange = (): void => {
+      setReducedMotion(media.matches);
+    };
     media.addEventListener("change", onChange);
-    return () => media.removeEventListener("change", onChange);
+    return () => {
+      media.removeEventListener("change", onChange);
+    };
   }, []);
 
   useEffect(() => {
@@ -70,7 +74,9 @@ export const LemonsvilleScene = ({
     }
 
     controllerRef.current = controller;
-    const resize = (): void => controller.resize(canvas.clientWidth, canvas.clientHeight);
+    const resize = (): void => {
+      controller.resize(canvas.clientWidth, canvas.clientHeight);
+    };
     const observer = new ResizeObserver(resize);
     observer.observe(canvas);
     resize();
@@ -86,7 +92,7 @@ export const LemonsvilleScene = ({
     controllerRef.current?.update(sceneState);
   }, [sceneState]);
 
-  const description = `${environment.weather.kind.replaceAll("-", " ")} weather; ${environment.sentiment.kind.replaceAll("-", " ")} market sentiment; ${visibleSigns} advertising signs visible.`;
+  const description = `${environment.weather.kind.replaceAll("-", " ")} weather; ${environment.sentiment.kind.replaceAll("-", " ")} market sentiment; ${String(visibleSigns)} advertising signs visible.`;
 
   return (
     <section className="stand-stage" aria-label="Lemonsville lemonade stand">

--- a/apps/web/src/finance.css
+++ b/apps/web/src/finance.css
@@ -1,0 +1,102 @@
+.obligation-strip {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 0 0 18px;
+  padding: 10px 14px;
+  border: 2px solid #211d14;
+  background: #fff9e4;
+  box-shadow: 4px 4px 0 #211d14;
+}
+
+.obligation-strip strong {
+  flex: 0 0 auto;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  text-transform: uppercase;
+}
+
+.obligation-strip span {
+  color: #5d5749;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.ledger-breakdown {
+  margin: 18px 0;
+  border: 2px solid #211d14;
+  background: #fffdf3;
+}
+
+.ledger-breakdown h3 {
+  margin: 0;
+  padding: 12px 14px;
+  border-bottom: 2px solid #211d14;
+  background: #f7cf52;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.ledger-breakdown table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.ledger-breakdown caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.ledger-breakdown th,
+.ledger-breakdown td {
+  padding: 9px 14px;
+  border-bottom: 1px solid #d9cda9;
+}
+
+.ledger-breakdown th {
+  font-weight: 650;
+  text-align: left;
+}
+
+.ledger-breakdown td {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-weight: 800;
+  text-align: right;
+}
+
+.ledger-breakdown tr:last-child > * {
+  border-bottom: 0;
+}
+
+.ledger-credit {
+  color: #236f5e;
+}
+
+.ledger-debit {
+  color: #9a2e26;
+}
+
+.progression-note {
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  border: 2px solid #211d14;
+  background: #f7cf52;
+  font-weight: 800;
+}
+
+@media (max-width: 760px) {
+  .obligation-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .obligation-strip span {
+    text-align: left;
+  }
+}

--- a/apps/web/src/history.css
+++ b/apps/web/src/history.css
@@ -54,11 +54,19 @@
 }
 
 .chart-cash,
-.chart-sold {
+.chart-sold,
+.legend-cash,
+.legend-sold {
   color: #236f5e;
 }
 
-.chart-prepared {
+.chart-debt,
+.legend-debt {
+  color: #9a2e26;
+}
+
+.chart-prepared,
+.legend-prepared {
   color: #a9631a;
 }
 
@@ -83,14 +91,6 @@
   background: currentColor;
 }
 
-.legend-prepared {
-  color: #a9631a;
-}
-
-.legend-sold {
-  color: #236f5e;
-}
-
 .history-table-wrap {
   overflow-x: auto;
   margin-top: 18px;
@@ -99,7 +99,7 @@
 
 .history-table {
   width: 100%;
-  min-width: 720px;
+  min-width: 1120px;
   border-collapse: collapse;
   background: #fffdf3;
   font-variant-numeric: tabular-nums;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { App } from "./App.js";
 import "./styles.css";
 import "./scene.css";
 import "./history.css";
+import "./finance.css";
 
 const root = document.getElementById("root");
 if (root === null) {

--- a/e2e/daily-loop.spec.ts
+++ b/e2e/daily-loop.spec.ts
@@ -29,6 +29,6 @@ test("prevents an unaffordable plan before submission", async ({ page }) => {
   await signs.focus();
   await page.keyboard.press("End");
 
-  await expect(page.getByRole("alert")).toContainText("costs more cash");
+  await expect(page.getByRole("alert")).toContainText("available cash and credit");
   await expect(page.getByRole("button", { name: "Sell for the day" })).toBeDisabled();
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const typedSources = [
   "e2e/**/*.ts",
   "*.config.ts",
 ];
+const scopeTypedConfig = (config) => ({ ...config, files: typedSources });
 
 export default tseslint.config(
   {
@@ -14,12 +15,13 @@ export default tseslint.config(
       "build/**",
       "dist/**",
       "node_modules/**",
+      "public/**",
       "*.js",
       "legacy/**",
     ],
   },
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked.map(scopeTypedConfig),
+  ...tseslint.configs.stylisticTypeChecked.map(scopeTypedConfig),
   {
     files: typedSources,
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {
-    "@eslint/js": "^10.10.0",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.63.0",
     "@types/node": "^24.0.0",
     "eslint": "^10.10.0",

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "three": "^0.186.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.185.4"
   }
 }

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -126,11 +126,21 @@ const createCustomer = (index: number): THREE.Group => {
   return customer;
 };
 
+type DisposableMesh = THREE.Mesh<THREE.BufferGeometry, THREE.Material | THREE.Material[]>;
+
+const isDisposableMesh = (object: THREE.Object3D): object is DisposableMesh =>
+  object instanceof THREE.Mesh;
+
 const disposeObject = (object: THREE.Object3D): void => {
-  if (!(object instanceof THREE.Mesh)) return;
+  if (!isDisposableMesh(object)) return;
   object.geometry.dispose();
-  const materials = Array.isArray(object.material) ? object.material : [object.material];
-  for (const material of materials) material.dispose();
+  if (Array.isArray(object.material)) {
+    for (const material of object.material) {
+      material.dispose();
+    }
+  } else {
+    object.material.dispose();
+  }
 };
 
 export const createLemonsvilleScene = (
@@ -182,7 +192,9 @@ export const createLemonsvilleScene = (
   const customers = Array.from({ length: 12 }, (_, index) => createCustomer(index));
   for (const customer of customers) scene.add(customer);
 
-  const render = (): void => renderer.render(scene, camera);
+  const render = (): void => {
+    renderer.render(scene, camera);
+  };
 
   const update = (state: LemonsvilleSceneState): void => {
     renderer.setClearColor(skyColor[state.weather], 1);

--- a/packages/simulation/src/finance.ts
+++ b/packages/simulation/src/finance.ts
@@ -90,5 +90,10 @@ export const remainingCredit = (state: GameState): MoneyCents => {
 export const availableOperatingFunds = (state: GameState): MoneyCents =>
   moneyCents(Number(state.cash) + Number(remainingCredit(state)));
 
+export const predictableFixedObligations = (state: GameState): MoneyCents => {
+  const rules = financeRulesForTier(state.tier);
+  return moneyCents(Number(rules.supplierFee) + Number(rules.bankFee));
+};
+
 export const applyBasisPoints = (amountCents: number, rate: BasisPoints): MoneyCents =>
   moneyCents(Math.round((amountCents * Number(rate)) / 10_000));

--- a/packages/simulation/src/finance.ts
+++ b/packages/simulation/src/finance.ts
@@ -1,0 +1,94 @@
+import type { GameState, ProgressionTier } from "./model.js";
+import {
+  basisPoints,
+  moneyCents,
+  type BasisPoints,
+  type DayNumber,
+  type MoneyCents,
+} from "./primitives.js";
+
+export type FinanceRules = Readonly<{
+  tier: ProgressionTier;
+  supplierFee: MoneyCents;
+  taxRate: BasisPoints;
+  bankFee: MoneyCents;
+  savingsInterestRate: BasisPoints;
+  loanInterestRate: BasisPoints;
+  creditLimit: MoneyCents;
+  workingCashReserve: MoneyCents;
+}>;
+
+const RULES: Readonly<Record<ProgressionTier, FinanceRules>> = Object.freeze({
+  0: Object.freeze({
+    tier: 0,
+    supplierFee: moneyCents(0),
+    taxRate: basisPoints(0),
+    bankFee: moneyCents(0),
+    savingsInterestRate: basisPoints(0),
+    loanInterestRate: basisPoints(0),
+    creditLimit: moneyCents(0),
+    workingCashReserve: moneyCents(0),
+  }),
+  1: Object.freeze({
+    tier: 1,
+    supplierFee: moneyCents(5),
+    taxRate: basisPoints(0),
+    bankFee: moneyCents(0),
+    savingsInterestRate: basisPoints(0),
+    loanInterestRate: basisPoints(0),
+    creditLimit: moneyCents(0),
+    workingCashReserve: moneyCents(0),
+  }),
+  2: Object.freeze({
+    tier: 2,
+    supplierFee: moneyCents(10),
+    taxRate: basisPoints(500),
+    bankFee: moneyCents(0),
+    savingsInterestRate: basisPoints(0),
+    loanInterestRate: basisPoints(0),
+    creditLimit: moneyCents(0),
+    workingCashReserve: moneyCents(0),
+  }),
+  3: Object.freeze({
+    tier: 3,
+    supplierFee: moneyCents(10),
+    taxRate: basisPoints(750),
+    bankFee: moneyCents(5),
+    savingsInterestRate: basisPoints(10),
+    loanInterestRate: basisPoints(40),
+    creditLimit: moneyCents(500),
+    workingCashReserve: moneyCents(200),
+  }),
+  4: Object.freeze({
+    tier: 4,
+    supplierFee: moneyCents(15),
+    taxRate: basisPoints(1_000),
+    bankFee: moneyCents(10),
+    savingsInterestRate: basisPoints(15),
+    loanInterestRate: basisPoints(60),
+    creditLimit: moneyCents(2_000),
+    workingCashReserve: moneyCents(500),
+  }),
+});
+
+export const financeRulesForTier = (tier: ProgressionTier): FinanceRules => RULES[tier];
+
+export const progressionTierForDay = (day: DayNumber): ProgressionTier => {
+  const value = Number(day);
+  if (value < 7) return 0;
+  if (value < 14) return 1;
+  if (value < 21) return 2;
+  if (value < 35) return 3;
+  return 4;
+};
+
+export const remainingCredit = (state: GameState): MoneyCents => {
+  const limit = Number(financeRulesForTier(state.tier).creditLimit);
+  return moneyCents(Math.max(0, limit - Number(state.loanBalance)));
+};
+
+export const availableOperatingFunds = (state: GameState): MoneyCents =>
+  moneyCents(Number(state.cash) + Number(remainingCredit(state)));
+
+export const applyBasisPoints = (amountCents: number, rate: BasisPoints): MoneyCents =>
+  moneyCents(Math.round((amountCents * Number(rate)) / 10_000));

--- a/packages/simulation/src/finance.ts
+++ b/packages/simulation/src/finance.ts
@@ -3,7 +3,6 @@ import {
   basisPoints,
   moneyCents,
   type BasisPoints,
-  type DayNumber,
   type MoneyCents,
 } from "./primitives.js";
 
@@ -17,6 +16,13 @@ export type FinanceRules = Readonly<{
   creditLimit: MoneyCents;
   workingCashReserve: MoneyCents;
 }>;
+
+export const EQUITY_TIER_THRESHOLDS_CENTS = Object.freeze({
+  tier1: 500,
+  tier2: 2_000,
+  tier3: 5_000,
+  tier4: 10_000,
+});
 
 const RULES: Readonly<Record<ProgressionTier, FinanceRules>> = Object.freeze({
   0: Object.freeze({
@@ -73,13 +79,20 @@ const RULES: Readonly<Record<ProgressionTier, FinanceRules>> = Object.freeze({
 
 export const financeRulesForTier = (tier: ProgressionTier): FinanceRules => RULES[tier];
 
-export const progressionTierForDay = (day: DayNumber): ProgressionTier => {
-  const value = Number(day);
-  if (value < 7) return 0;
-  if (value < 14) return 1;
-  if (value < 21) return 2;
-  if (value < 35) return 3;
+export const progressionTierForEquity = (equityCents: number): ProgressionTier => {
+  if (equityCents < EQUITY_TIER_THRESHOLDS_CENTS.tier1) return 0;
+  if (equityCents < EQUITY_TIER_THRESHOLDS_CENTS.tier2) return 1;
+  if (equityCents < EQUITY_TIER_THRESHOLDS_CENTS.tier3) return 2;
+  if (equityCents < EQUITY_TIER_THRESHOLDS_CENTS.tier4) return 3;
   return 4;
+};
+
+export const nextProgressionTier = (
+  currentTier: ProgressionTier,
+  equityCents: number,
+): ProgressionTier => {
+  const candidate = progressionTierForEquity(equityCents);
+  return candidate > currentTier ? candidate : currentTier;
 };
 
 export const remainingCredit = (state: GameState): MoneyCents => {

--- a/packages/simulation/src/finance.ts
+++ b/packages/simulation/src/finance.ts
@@ -92,7 +92,19 @@ export const nextProgressionTier = (
   equityCents: number,
 ): ProgressionTier => {
   const candidate = progressionTierForEquity(equityCents);
-  return candidate > currentTier ? candidate : currentTier;
+  if (candidate <= currentTier) return currentTier;
+
+  switch (currentTier) {
+    case 0:
+      return 1;
+    case 1:
+      return 2;
+    case 2:
+      return 3;
+    case 3:
+    case 4:
+      return 4;
+  }
 };
 
 export const remainingCredit = (state: GameState): MoneyCents => {

--- a/packages/simulation/src/index.ts
+++ b/packages/simulation/src/index.ts
@@ -1,6 +1,7 @@
-export const SIMULATION_SCHEMA_VERSION = 1 as const;
+export const SIMULATION_SCHEMA_VERSION = 2 as const;
 
 export * from "./environment.js";
+export * from "./finance.js";
 export * from "./model.js";
 export * from "./primitives.js";
 export * from "./rng.js";

--- a/packages/simulation/src/model.ts
+++ b/packages/simulation/src/model.ts
@@ -37,6 +37,8 @@ export type DayDecision = Readonly<{
   price: MoneyCents;
 }>;
 
+export type ProgressionTier = 0 | 1 | 2 | 3 | 4;
+
 export type LedgerLineKind =
   | "revenue"
   | "production"
@@ -45,7 +47,9 @@ export type LedgerLineKind =
   | "tax"
   | "bank-fee"
   | "savings-interest"
-  | "loan-interest";
+  | "loan-interest"
+  | "loan-draw"
+  | "loan-repayment";
 
 export type LedgerLine = Readonly<{
   kind: LedgerLineKind;
@@ -56,22 +60,27 @@ export type LedgerLine = Readonly<{
 
 export type DailyLedgerEntry = Readonly<{
   day: DayNumber;
+  tier: ProgressionTier;
   decision: DayDecision;
   environment: DayEnvironment;
   potentialDemand: GlassCount;
   sold: GlassCount;
   revenue: MoneyCents;
+  financeIncome: MoneyCents;
   expenses: MoneyCents;
   net: SignedMoneyCents;
+  cashDelta: SignedMoneyCents;
+  borrowed: MoneyCents;
+  repaid: MoneyCents;
   endingCash: MoneyCents;
+  endingLoanBalance: MoneyCents;
   lines: readonly LedgerLine[];
 }>;
-
-export type ProgressionTier = 0 | 1 | 2 | 3 | 4;
 
 export type GameState = Readonly<{
   day: DayNumber;
   cash: MoneyCents;
+  loanBalance: MoneyCents;
   unitCost: MoneyCents;
   signCost: MoneyCents;
   tier: ProgressionTier;

--- a/packages/simulation/src/simulate.ts
+++ b/packages/simulation/src/simulate.ts
@@ -1,3 +1,9 @@
+import {
+  applyBasisPoints,
+  availableOperatingFunds,
+  financeRulesForTier,
+  progressionTierForDay,
+} from "./finance.js";
 import type {
   DailyLedgerEntry,
   DayDecision,
@@ -25,7 +31,7 @@ export class UnaffordableDecisionError extends Error {
   }
 }
 
-const decisionExpenses = (state: GameState, decision: DayDecision) =>
+const decisionVariableExpenses = (state: GameState, decision: DayDecision) =>
   moneyCents(
     Number(decision.glasses) * Number(state.unitCost) +
       Number(decision.signs) * Number(state.signCost),
@@ -46,6 +52,13 @@ const resolveSold = (
   return glassCount(Math.min(Number(decision.glasses), demand));
 };
 
+const ledgerLine = (
+  kind: LedgerLine["kind"],
+  label: string,
+  amount: ReturnType<typeof moneyCents>,
+  direction: LedgerLine["direction"],
+): LedgerLine => Object.freeze({ kind, label, amount, direction });
+
 export const simulateDay = (
   state: GameState,
   decision: DayDecision,
@@ -55,10 +68,24 @@ export const simulateDay = (
     throw new RangeError("price must be greater than zero");
   }
 
-  const expenses = decisionExpenses(state, decision);
-  if (Number(expenses) > Number(state.cash)) {
-    throw new UnaffordableDecisionError(Number(expenses), Number(state.cash));
+  const finance = financeRulesForTier(state.tier);
+  const variableExpenses = decisionVariableExpenses(state, decision);
+  const predictableExpenses = moneyCents(
+    Number(variableExpenses) + Number(finance.supplierFee) + Number(finance.bankFee),
+  );
+  const operatingFunds = availableOperatingFunds(state);
+
+  if (Number(predictableExpenses) > Number(operatingFunds)) {
+    throw new UnaffordableDecisionError(
+      Number(predictableExpenses),
+      Number(operatingFunds),
+    );
   }
+
+  const openingCashCents = Number(state.cash);
+  const initialBorrowCents = Math.max(0, Number(predictableExpenses) - openingCashCents);
+  let loanBalanceCents = Number(state.loanBalance) + initialBorrowCents;
+  let cashCents = openingCashCents + initialBorrowCents - Number(predictableExpenses);
 
   const calculatedDemand = potentialDemand(decision.price, decision.signs, environment);
   const sold = resolveSold(decision, environment, Number(calculatedDemand));
@@ -69,50 +96,117 @@ export const simulateDay = (
       : calculatedDemand;
 
   const revenue = moneyCents(Number(sold) * Number(decision.price));
-  const net = signedMoneyCents(Number(revenue) - Number(expenses));
-  const endingCash = moneyCents(Number(state.cash) + Number(net));
-  const nextDay = dayNumber(Number(state.day) + 1);
+  cashCents += Number(revenue);
 
-  const lines: readonly LedgerLine[] = Object.freeze([
-    Object.freeze({
-      kind: "revenue",
-      label: "Lemonade sales",
-      amount: revenue,
-      direction: "credit",
-    }),
-    Object.freeze({
-      kind: "production",
-      label: "Prepared glasses",
-      amount: moneyCents(Number(decision.glasses) * Number(state.unitCost)),
-      direction: "debit",
-    }),
-    Object.freeze({
-      kind: "advertising",
-      label: "Advertising signs",
-      amount: moneyCents(Number(decision.signs) * Number(state.signCost)),
-      direction: "debit",
-    }),
-  ]);
+  const taxableOperatingProfitCents = Math.max(
+    0,
+    Number(revenue) - Number(predictableExpenses),
+  );
+  const tax = applyBasisPoints(taxableOperatingProfitCents, finance.taxRate);
+  cashCents -= Number(tax);
+
+  const loanInterest = applyBasisPoints(loanBalanceCents, finance.loanInterestRate);
+  const paidLoanInterestCents = Math.min(cashCents, Number(loanInterest));
+  cashCents -= paidLoanInterestCents;
+  loanBalanceCents += Number(loanInterest) - paidLoanInterestCents;
+
+  const availableForRepaymentCents = Math.max(
+    0,
+    cashCents - Number(finance.workingCashReserve),
+  );
+  const repaidCents = Math.min(loanBalanceCents, availableForRepaymentCents);
+  cashCents -= repaidCents;
+  loanBalanceCents -= repaidCents;
+
+  const savingsInterest =
+    loanBalanceCents === 0
+      ? applyBasisPoints(cashCents, finance.savingsInterestRate)
+      : moneyCents(0);
+  cashCents += Number(savingsInterest);
+
+  const borrowed = moneyCents(initialBorrowCents);
+  const repaid = moneyCents(repaidCents);
+  const expenses = moneyCents(
+    Number(predictableExpenses) + Number(tax) + Number(loanInterest),
+  );
+  const financeIncome = savingsInterest;
+  const net = signedMoneyCents(
+    Number(revenue) + Number(financeIncome) - Number(expenses),
+  );
+  const endingCash = moneyCents(cashCents);
+  const endingLoanBalance = moneyCents(loanBalanceCents);
+  const cashDelta = signedMoneyCents(Number(endingCash) - openingCashCents);
+  const nextDay = dayNumber(Number(state.day) + 1);
+  const nextTier = progressionTierForDay(nextDay);
+
+  const lines: LedgerLine[] = [
+    ledgerLine("revenue", "Lemonade sales", revenue, "credit"),
+    ledgerLine(
+      "production",
+      "Prepared glasses",
+      moneyCents(Number(decision.glasses) * Number(state.unitCost)),
+      "debit",
+    ),
+    ledgerLine(
+      "advertising",
+      "Advertising signs",
+      moneyCents(Number(decision.signs) * Number(state.signCost)),
+      "debit",
+    ),
+  ];
+
+  if (Number(finance.supplierFee) > 0) {
+    lines.push(
+      ledgerLine("operating-fee", "Supplier delivery", finance.supplierFee, "debit"),
+    );
+  }
+  if (Number(finance.bankFee) > 0) {
+    lines.push(ledgerLine("bank-fee", "Bank account fee", finance.bankFee, "debit"));
+  }
+  if (Number(tax) > 0) {
+    lines.push(ledgerLine("tax", "Business tax", tax, "debit"));
+  }
+  if (Number(borrowed) > 0) {
+    lines.push(ledgerLine("loan-draw", "Working-capital credit", borrowed, "credit"));
+  }
+  if (Number(loanInterest) > 0) {
+    lines.push(ledgerLine("loan-interest", "Credit interest", loanInterest, "debit"));
+  }
+  if (Number(repaid) > 0) {
+    lines.push(ledgerLine("loan-repayment", "Automatic credit repayment", repaid, "debit"));
+  }
+  if (Number(savingsInterest) > 0) {
+    lines.push(
+      ledgerLine("savings-interest", "Cash-account interest", savingsInterest, "credit"),
+    );
+  }
 
   const entry: DailyLedgerEntry = Object.freeze({
     day: state.day,
+    tier: state.tier,
     decision,
     environment,
     potentialDemand: reportedDemand,
     sold,
     revenue,
+    financeIncome,
     expenses,
     net,
+    cashDelta,
+    borrowed,
+    repaid,
     endingCash,
-    lines,
+    endingLoanBalance,
+    lines: Object.freeze(lines),
   });
 
   const nextState: GameState = Object.freeze({
     day: nextDay,
     cash: endingCash,
+    loanBalance: endingLoanBalance,
     unitCost: productionCostForDay(nextDay),
     signCost: state.signCost,
-    tier: state.tier,
+    tier: nextTier,
     ledger: Object.freeze([...state.ledger, entry]),
   });
 

--- a/packages/simulation/src/simulate.ts
+++ b/packages/simulation/src/simulate.ts
@@ -2,7 +2,7 @@ import {
   applyBasisPoints,
   availableOperatingFunds,
   financeRulesForTier,
-  progressionTierForDay,
+  nextProgressionTier,
 } from "./finance.js";
 import type {
   DailyLedgerEntry,
@@ -137,7 +137,10 @@ export const simulateDay = (
   const endingLoanBalance = moneyCents(loanBalanceCents);
   const cashDelta = signedMoneyCents(Number(endingCash) - openingCashCents);
   const nextDay = dayNumber(Number(state.day) + 1);
-  const nextTier = progressionTierForDay(nextDay);
+  const nextTier = nextProgressionTier(
+    state.tier,
+    Number(endingCash) - Number(endingLoanBalance),
+  );
 
   const lines: LedgerLine[] = [
     ledgerLine("revenue", "Lemonade sales", revenue, "credit"),

--- a/packages/simulation/src/simulate.ts
+++ b/packages/simulation/src/simulate.ts
@@ -26,7 +26,9 @@ export class UnaffordableDecisionError extends Error {
     public readonly requiredCents: number,
     public readonly availableCents: number,
   ) {
-    super(`decision costs ${requiredCents} cents but only ${availableCents} are available`);
+    super(
+      `decision costs ${String(requiredCents)} cents but only ${String(availableCents)} are available`,
+    );
     this.name = "UnaffordableDecisionError";
   }
 }

--- a/packages/simulation/src/state.ts
+++ b/packages/simulation/src/state.ts
@@ -12,6 +12,7 @@ export const createInitialState = (): GameState =>
   Object.freeze({
     day: dayNumber(1),
     cash: moneyCents(200),
+    loanBalance: moneyCents(0),
     unitCost: moneyCents(2),
     signCost: moneyCents(15),
     tier: 0,

--- a/packages/simulation/test/finance.test.ts
+++ b/packages/simulation/test/finance.test.ts
@@ -129,4 +129,25 @@ describe("finance progression", () => {
     expect(Number(result.entry.endingCash)).toBe(986);
     expect(result.entry.lines.some((line) => line.kind === "savings-interest")).toBe(true);
   });
+
+  it("conserves business equity across operating and financing flows", () => {
+    const states = [
+      stateFor(14, 2, 1_000),
+      stateFor(21, 3, 5),
+      stateFor(21, 3, 100, 500),
+      stateFor(35, 4, 750, 250),
+    ] as const;
+
+    for (const state of states) {
+      const result = simulateDay(state, decision(10, 0, 10), neutralEnvironment());
+      const openingEquity = Number(state.cash) - Number(state.loanBalance);
+      const endingEquity =
+        Number(result.entry.endingCash) - Number(result.entry.endingLoanBalance);
+
+      expect(endingEquity).toBe(openingEquity + Number(result.entry.net));
+      expect(Number(result.entry.cashDelta)).toBe(
+        Number(result.entry.endingCash) - Number(state.cash),
+      );
+    }
+  });
 });

--- a/packages/simulation/test/finance.test.ts
+++ b/packages/simulation/test/finance.test.ts
@@ -8,7 +8,7 @@ import {
   glassCount,
   moneyCents,
   neutralEnvironment,
-  progressionTierForDay,
+  progressionTierForEquity,
   signCount,
   simulateDay,
   type DayDecision,
@@ -39,24 +39,25 @@ const stateFor = (
   });
 
 describe("finance progression", () => {
-  it("unlocks finance complexity by day without adding decision variables", () => {
-    expect(progressionTierForDay(dayNumber(1))).toBe(0);
-    expect(progressionTierForDay(dayNumber(7))).toBe(1);
-    expect(progressionTierForDay(dayNumber(14))).toBe(2);
-    expect(progressionTierForDay(dayNumber(21))).toBe(3);
-    expect(progressionTierForDay(dayNumber(35))).toBe(4);
+  it("unlocks finance complexity from business equity without adding decision variables", () => {
+    expect(progressionTierForEquity(0)).toBe(0);
+    expect(progressionTierForEquity(500)).toBe(1);
+    expect(progressionTierForEquity(2_000)).toBe(2);
+    expect(progressionTierForEquity(5_000)).toBe(3);
+    expect(progressionTierForEquity(10_000)).toBe(4);
 
     expect(Number(financeRulesForTier(0).creditLimit)).toBe(0);
     expect(Number(financeRulesForTier(3).creditLimit)).toBeGreaterThan(0);
   });
 
-  it("advances the stored tier at the boundary for the next forecast", () => {
+  it("advances the stored tier when ending equity crosses a threshold", () => {
     const result = simulateDay(
-      stateFor(6, 0, 1_000),
+      stateFor(6, 0, 440),
       decision(10, 0, 10),
       neutralEnvironment(),
     );
 
+    expect(Number(result.entry.endingCash)).toBe(500);
     expect(result.entry.tier).toBe(0);
     expect(result.nextState.tier).toBe(1);
   });

--- a/packages/simulation/test/finance.test.ts
+++ b/packages/simulation/test/finance.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  availableOperatingFunds,
+  createInitialState,
+  dayNumber,
+  financeRulesForTier,
+  glassCount,
+  moneyCents,
+  neutralEnvironment,
+  progressionTierForDay,
+  signCount,
+  simulateDay,
+  type DayDecision,
+  type GameState,
+  type ProgressionTier,
+} from "../src/index.js";
+
+const decision = (glasses: number, signs: number, price: number): DayDecision =>
+  Object.freeze({
+    glasses: glassCount(glasses),
+    signs: signCount(signs),
+    price: moneyCents(price),
+  });
+
+const stateFor = (
+  day: number,
+  tier: ProgressionTier,
+  cash: number,
+  loanBalance = 0,
+): GameState =>
+  Object.freeze({
+    ...createInitialState(),
+    day: dayNumber(day),
+    tier,
+    cash: moneyCents(cash),
+    loanBalance: moneyCents(loanBalance),
+    unitCost: moneyCents(day <= 2 ? 2 : day <= 6 ? 4 : 5),
+  });
+
+describe("finance progression", () => {
+  it("unlocks finance complexity by day without adding decision variables", () => {
+    expect(progressionTierForDay(dayNumber(1))).toBe(0);
+    expect(progressionTierForDay(dayNumber(7))).toBe(1);
+    expect(progressionTierForDay(dayNumber(14))).toBe(2);
+    expect(progressionTierForDay(dayNumber(21))).toBe(3);
+    expect(progressionTierForDay(dayNumber(35))).toBe(4);
+
+    expect(Number(financeRulesForTier(0).creditLimit)).toBe(0);
+    expect(Number(financeRulesForTier(3).creditLimit)).toBeGreaterThan(0);
+  });
+
+  it("advances the stored tier at the boundary for the next forecast", () => {
+    const result = simulateDay(
+      stateFor(6, 0, 1_000),
+      decision(10, 0, 10),
+      neutralEnvironment(),
+    );
+
+    expect(result.entry.tier).toBe(0);
+    expect(result.nextState.tier).toBe(1);
+  });
+
+  it("adds supplier fees before taxes", () => {
+    const result = simulateDay(
+      stateFor(7, 1, 1_000),
+      decision(10, 0, 10),
+      neutralEnvironment(),
+    );
+
+    expect(Number(result.entry.expenses)).toBe(55);
+    expect(Number(result.entry.net)).toBe(45);
+    expect(result.entry.lines.some((line) => line.kind === "operating-fee")).toBe(true);
+    expect(result.entry.lines.some((line) => line.kind === "tax")).toBe(false);
+  });
+
+  it("taxes only positive operating profit", () => {
+    const profit = simulateDay(
+      stateFor(14, 2, 1_000),
+      decision(10, 0, 10),
+      neutralEnvironment(),
+    );
+    const loss = simulateDay(
+      stateFor(14, 2, 1_000),
+      decision(10, 0, 1),
+      neutralEnvironment(),
+    );
+
+    const profitTax = profit.entry.lines.find((line) => line.kind === "tax");
+    expect(Number(profitTax?.amount ?? 0)).toBe(2);
+    expect(loss.entry.lines.some((line) => line.kind === "tax")).toBe(false);
+  });
+
+  it("uses working-capital credit automatically when the three-control plan exceeds cash", () => {
+    const state = stateFor(21, 3, 5);
+    expect(Number(availableOperatingFunds(state))).toBe(505);
+
+    const result = simulateDay(state, decision(10, 0, 10), neutralEnvironment());
+
+    expect(Number(result.entry.borrowed)).toBe(60);
+    expect(Number(result.entry.endingLoanBalance)).toBe(60);
+    expect(Number(result.entry.endingCash)).toBe(97);
+    expect(result.entry.lines.some((line) => line.kind === "loan-draw")).toBe(true);
+  });
+
+  it("charges loan interest without counting principal as an expense", () => {
+    const result = simulateDay(
+      stateFor(21, 3, 100, 500),
+      decision(0, 0, 10),
+      neutralEnvironment(),
+    );
+
+    const interest = result.entry.lines.find((line) => line.kind === "loan-interest");
+    expect(Number(interest?.amount ?? 0)).toBe(2);
+    expect(Number(result.entry.expenses)).toBe(17);
+    expect(Number(result.entry.borrowed)).toBe(0);
+  });
+
+  it("credits savings interest only when no loan remains", () => {
+    const result = simulateDay(
+      stateFor(21, 3, 1_000),
+      decision(0, 0, 10),
+      neutralEnvironment(),
+    );
+
+    expect(Number(result.entry.financeIncome)).toBe(1);
+    expect(Number(result.entry.net)).toBe(-14);
+    expect(Number(result.entry.endingCash)).toBe(986);
+    expect(result.entry.lines.some((line) => line.kind === "savings-interest")).toBe(true);
+  });
+});

--- a/packages/simulation/test/simulation.test.ts
+++ b/packages/simulation/test/simulation.test.ts
@@ -71,7 +71,7 @@ describe("day resolution", () => {
   it("rejects spending that exceeds available cash", () => {
     expect(() =>
       simulateDay(createInitialState(), decision(100, 1, 10), neutralEnvironment()),
-    ).toThrowError(UnaffordableDecisionError);
+    ).toThrow(UnaffordableDecisionError);
   });
 
   it("keeps thunderstorms economically decisive without presentation timing", () => {

--- a/packages/ui/src/LedgerHistory.tsx
+++ b/packages/ui/src/LedgerHistory.tsx
@@ -5,6 +5,7 @@ import { projectLedger, sellThroughBasisPoints, type LedgerPoint } from "./ledge
 const CHART_WIDTH = 720;
 const CHART_HEIGHT = 180;
 const CHART_PADDING = 18;
+const CHART_VIEW_BOX = "0 0 720 180";
 
 const moneyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -90,7 +91,7 @@ export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
           <figcaption>Cash and debt over time</figcaption>
           <svg
             className="history-chart"
-            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+            viewBox={CHART_VIEW_BOX}
             role="img"
             aria-label={`Balance history from ${formatMoney(first.endingCashCents)} cash and ${formatMoney(first.endingDebtCents)} debt to ${formatMoney(latest.endingCashCents)} cash and ${formatMoney(latest.endingDebtCents)} debt`}
           >
@@ -114,9 +115,9 @@ export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
           <figcaption>Prepared vs sold</figcaption>
           <svg
             className="history-chart"
-            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+            viewBox={CHART_VIEW_BOX}
             role="img"
-            aria-label={`Inventory history across ${points.length} day${points.length === 1 ? "" : "s"}`}
+            aria-label={`Inventory history across ${String(points.length)} day${points.length === 1 ? "" : "s"}`}
           >
             <line
               className="chart-axis"

--- a/packages/ui/src/LedgerHistory.tsx
+++ b/packages/ui/src/LedgerHistory.tsx
@@ -35,10 +35,16 @@ const seriesPoints = (
     .join(" ");
 };
 
-const cashTrend = (points: readonly LedgerPoint[]): string => {
-  const values = points.map((point) => point.endingCashCents);
-  if (values.length === 0) return "";
-  return seriesPoints(values, Math.min(...values), Math.max(...values));
+const balanceTrends = (
+  points: readonly LedgerPoint[],
+): Readonly<{ cash: string; debt: string }> => {
+  const cash = points.map((point) => point.endingCashCents);
+  const debt = points.map((point) => point.endingDebtCents);
+  const maximum = Math.max(1, ...cash, ...debt);
+  return Object.freeze({
+    cash: seriesPoints(cash, 0, maximum),
+    debt: seriesPoints(debt, 0, maximum),
+  });
 };
 
 const inventoryTrends = (
@@ -61,10 +67,11 @@ export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
   const points = projectLedger(entries);
   if (points.length === 0) return null;
 
-  const cash = cashTrend(points);
+  const balances = balanceTrends(points);
   const inventory = inventoryTrends(points);
   const latest = points.at(-1);
-  if (latest === undefined) return null;
+  const first = points.at(0);
+  if (latest === undefined || first === undefined) return null;
 
   return (
     <section className="ledger-history" aria-labelledby="ledger-history-title">
@@ -80,12 +87,12 @@ export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
 
       <div className="chart-grid">
         <figure className="chart-card">
-          <figcaption>Cash over time</figcaption>
+          <figcaption>Cash and debt over time</figcaption>
           <svg
             className="history-chart"
             viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
             role="img"
-            aria-label={`Cash history from ${formatMoney(points[0]?.endingCashCents ?? 0)} to ${formatMoney(latest.endingCashCents)}`}
+            aria-label={`Balance history from ${formatMoney(first.endingCashCents)} cash and ${formatMoney(first.endingDebtCents)} debt to ${formatMoney(latest.endingCashCents)} cash and ${formatMoney(latest.endingDebtCents)} debt`}
           >
             <line
               className="chart-axis"
@@ -94,8 +101,13 @@ export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
               x2={CHART_WIDTH - CHART_PADDING}
               y2={CHART_HEIGHT - CHART_PADDING}
             />
-            <polyline className="chart-line chart-cash" points={cash} />
+            <polyline className="chart-line chart-cash" points={balances.cash} />
+            <polyline className="chart-line chart-debt" points={balances.debt} />
           </svg>
+          <div className="chart-legend" aria-hidden="true">
+            <span><i className="legend-cash" />Cash</span>
+            <span><i className="legend-debt" />Debt</span>
+          </div>
         </figure>
 
         <figure className="chart-card">
@@ -125,30 +137,40 @@ export const LedgerHistory = ({ entries }: LedgerHistoryProps) => {
 
       <div className="history-table-wrap">
         <table className="history-table">
-          <caption>Complete values represented by the sales-history charts</caption>
+          <caption>Complete values represented by the sales-history charts and finance ledger</caption>
           <thead>
             <tr>
               <th scope="col">Day</th>
+              <th scope="col">Tier</th>
               <th scope="col">Prepared</th>
               <th scope="col">Sold</th>
               <th scope="col">Price</th>
-              <th scope="col">Revenue</th>
+              <th scope="col">Sales</th>
+              <th scope="col">Finance income</th>
               <th scope="col">Expenses</th>
               <th scope="col">Net</th>
+              <th scope="col">Borrowed</th>
+              <th scope="col">Repaid</th>
               <th scope="col">Cash</th>
+              <th scope="col">Debt</th>
             </tr>
           </thead>
           <tbody>
             {points.map((point) => (
               <tr key={point.day}>
                 <th scope="row">{point.day}</th>
+                <td>{point.tier}</td>
                 <td>{point.prepared}</td>
                 <td>{point.sold}</td>
                 <td>{formatMoney(point.priceCents)}</td>
                 <td>{formatMoney(point.revenueCents)}</td>
+                <td>{formatMoney(point.financeIncomeCents)}</td>
                 <td>{formatMoney(point.expensesCents)}</td>
                 <td>{point.netCents >= 0 ? "+" : "−"}{formatMoney(Math.abs(point.netCents))}</td>
+                <td>{formatMoney(point.borrowedCents)}</td>
+                <td>{formatMoney(point.repaidCents)}</td>
                 <td>{formatMoney(point.endingCashCents)}</td>
+                <td>{formatMoney(point.endingDebtCents)}</td>
               </tr>
             ))}
           </tbody>

--- a/packages/ui/src/ledger.ts
+++ b/packages/ui/src/ledger.ts
@@ -2,13 +2,19 @@ import type { DailyLedgerEntry } from "@lemonade/simulation";
 
 export type LedgerPoint = Readonly<{
   day: number;
+  tier: number;
   prepared: number;
   sold: number;
   priceCents: number;
   revenueCents: number;
+  financeIncomeCents: number;
   expensesCents: number;
   netCents: number;
+  cashDeltaCents: number;
+  borrowedCents: number;
+  repaidCents: number;
   endingCashCents: number;
+  endingDebtCents: number;
 }>;
 
 export const projectLedger = (
@@ -18,13 +24,19 @@ export const projectLedger = (
     entries.map((entry) =>
       Object.freeze({
         day: Number(entry.day),
+        tier: entry.tier,
         prepared: Number(entry.decision.glasses),
         sold: Number(entry.sold),
         priceCents: Number(entry.decision.price),
         revenueCents: Number(entry.revenue),
+        financeIncomeCents: Number(entry.financeIncome),
         expensesCents: Number(entry.expenses),
         netCents: Number(entry.net),
+        cashDeltaCents: Number(entry.cashDelta),
+        borrowedCents: Number(entry.borrowed),
+        repaidCents: Number(entry.repaid),
         endingCashCents: Number(entry.endingCash),
+        endingDebtCents: Number(entry.endingLoanBalance),
       }),
     ),
   );

--- a/packages/ui/test/ledger.test.ts
+++ b/packages/ui/test/ledger.test.ts
@@ -12,9 +12,14 @@ import {
 
 import { projectLedger, sellThroughBasisPoints } from "../src/ledger.js";
 
-const entry = (day: number, prepared: number, sold: number): DailyLedgerEntry =>
-  Object.freeze({
+const entry = (day: number, prepared: number, sold: number): DailyLedgerEntry => {
+  const revenue = sold * 10;
+  const expenses = prepared * 2 + 15;
+  const net = revenue - expenses;
+
+  return Object.freeze({
     day: dayNumber(day),
+    tier: 0,
     decision: Object.freeze({
       glasses: glassCount(prepared),
       signs: signCount(1),
@@ -27,12 +32,18 @@ const entry = (day: number, prepared: number, sold: number): DailyLedgerEntry =>
     }),
     potentialDemand: glassCount(sold),
     sold: glassCount(sold),
-    revenue: moneyCents(sold * 10),
-    expenses: moneyCents(prepared * 2 + 15),
-    net: signedMoneyCents(sold * 10 - (prepared * 2 + 15)),
-    endingCash: moneyCents(200 + sold * 10 - (prepared * 2 + 15)),
+    revenue: moneyCents(revenue),
+    financeIncome: moneyCents(0),
+    expenses: moneyCents(expenses),
+    net: signedMoneyCents(net),
+    cashDelta: signedMoneyCents(net),
+    borrowed: moneyCents(0),
+    repaid: moneyCents(0),
+    endingCash: moneyCents(200 + net),
+    endingLoanBalance: moneyCents(0),
     lines: Object.freeze([]),
   });
+};
 
 const onlyPoint = (value: readonly DailyLedgerEntry[]) => {
   const point = projectLedger(value).at(0);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "@playwright/test";
 
+const isCI = Boolean(process.env["CI"]);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? "github" : "list",
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  reporter: isCI ? "github" : "list",
   use: {
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
@@ -13,6 +15,6 @@ export default defineConfig({
   webServer: {
     command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
   },
 });


### PR DESCRIPTION
## Outcome

Implements #7 as the final gameplay-system layer in the revival stack, based on ledger/charts PR #16.

The primary daily operating surface still has exactly three decisions — glasses, signs and price — plus `Sell for the day`. Finance is introduced as visible conditions and automatic consequences, never as a fourth mandatory daily control.

## Progressive rules

Growth is tied to business equity (`cash - debt`) and is monotonic. At most one tier can unlock per completed day so a windfall cannot expose several systems at once.

- Tier 0: classic neighborhood rules.
- Tier 1: supplier delivery fee.
- Tier 2: supplier fee plus tax on positive operating profit.
- Tier 3: bank fee, cash interest and a bounded working-capital credit facility with loan interest.
- Tier 4: mature fee/tax/interest rates and a larger credit facility.

Balance constants are intentionally isolated in `finance.ts` for later playtesting and tuning.

## Accounting model

`@lemonade/simulation` now records:
- sales revenue and separate finance income;
- production, advertising, supplier, tax, bank and loan-interest expenses;
- working-capital draws and principal repayments as balance-sheet movements rather than profit/loss;
- cash delta, ending cash and ending loan balance;
- the tier under which each immutable historical day was resolved.

Automatic credit can fund an otherwise unaffordable three-control plan within the tier's credit limit. Repayment preserves a configured working-cash reserve. Unpaid loan interest capitalizes into debt. Savings interest is credited only when no loan balance remains.

Tests assert the core balance-sheet invariant: ending equity equals opening equity plus operating net regardless of principal borrowing/repayment, and cash delta reconciles independently.

## Player presentation

The web UI adds only passive/informational surfaces:
- current business tier and applicable obligations before Sell;
- debt alongside cash once banking is relevant;
- operating-funds affordability including available credit;
- complete per-day ledger breakdown after resolution;
- a progression notice when tomorrow unlocks a new tier;
- cash-vs-debt history plus financing columns in the accessible history table.

The existing Playwright contract still asserts exactly three sliders and one Sell action. Its affordability copy assertion is updated to include cash and credit.

## Versioning

Simulation schema version advances from 1 to 2 because persisted state/ledger shape gains explicit finance fields.

## Stack dependency / validation

Base: `revival/ledger-charts` / PR #16. The complete implementation stack remains draft until bootstrap PR #11 receives a genuine pnpm-generated `pnpm-lock.yaml`. Connector-side source review was performed, but package installation, typecheck, lint, Vitest, build and Playwright have not been represented as executed.

Closes #7 when validated and merged through the stack.