### PR TITLE
Enable GitHub Actions Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for GitHub Pages
- deploy the existing tracked `public/` production bundle
- use the current official Pages actions and required OIDC/Page permissions
- support automatic deployment from `master` and manual dispatch
- serialize Pages deployments without cancelling an in-progress publish

## Rationale
The repository already has GitHub Pages enabled and commits its production output under `public/`. Deploying that directory directly avoids coupling Pages availability to the legacy Webpack 3 build chain while tooling modernization continues separately.