### PR TITLE
feat: begin Phase 8 versioned run persistence

### DIFF
--- a/apps/web/src/persistence.ts
+++ b/apps/web/src/persistence.ts
@@ -1,0 +1,574 @@
+import {
+  SIMULATION_SCHEMA_VERSION,
+  basisPoints,
+  dayNumber,
+  glassCount,
+  moneyCents,
+  seed,
+  signedMoneyCents,
+  signCount,
+  type DayDecision,
+  type DayEnvironment,
+  type DailyLedgerEntry,
+  type GameState,
+  type LedgerLine,
+  type ProgressionTier,
+  type Seed,
+} from "@lemonade/simulation";
+
+export const RUN_SAVE_SCHEMA_VERSION = 1 as const;
+
+const DATABASE_NAME = "lemonade";
+const DATABASE_VERSION = 1;
+const RUN_STORE_NAME = "runs";
+const CURRENT_RUN_KEY = "current";
+
+const ledgerLineKinds = [
+  "revenue",
+  "production",
+  "advertising",
+  "operating-fee",
+  "tax",
+  "bank-fee",
+  "savings-interest",
+  "loan-interest",
+  "loan-draw",
+  "loan-repayment",
+] as const;
+
+const weatherKinds = ["sunny", "cloudy", "hot-and-dry", "thunderstorm"] as const;
+const sentimentKinds = ["very-cold", "cold", "neutral", "warm", "hot"] as const;
+const eventKinds = ["none", "street-work", "workers-buy-out"] as const;
+const directions = ["credit", "debit"] as const;
+
+export type RunSnapshot = Readonly<{
+  seed: Seed;
+  state: GameState;
+  environment: DayEnvironment;
+  draft: DayDecision;
+}>;
+
+type SerializedDecision = Readonly<{
+  glasses: number;
+  signs: number;
+  price: number;
+}>;
+
+type SerializedMultiplierVariant = Readonly<{
+  kind: string;
+  demandMultiplier: number;
+}>;
+
+type SerializedEnvironment = Readonly<{
+  weather: SerializedMultiplierVariant;
+  sentiment: SerializedMultiplierVariant;
+  event: SerializedMultiplierVariant;
+}>;
+
+type SerializedLedgerLine = Readonly<{
+  kind: string;
+  label: string;
+  amount: number;
+  direction: string;
+}>;
+
+type SerializedLedgerEntry = Readonly<{
+  day: number;
+  tier: number;
+  decision: SerializedDecision;
+  environment: SerializedEnvironment;
+  potentialDemand: number;
+  sold: number;
+  revenue: number;
+  financeIncome: number;
+  expenses: number;
+  net: number;
+  cashDelta: number;
+  borrowed: number;
+  repaid: number;
+  endingCash: number;
+  endingLoanBalance: number;
+  lines: readonly SerializedLedgerLine[];
+}>;
+
+type SerializedGameState = Readonly<{
+  day: number;
+  cash: number;
+  loanBalance: number;
+  unitCost: number;
+  signCost: number;
+  tier: number;
+  ledger: readonly SerializedLedgerEntry[];
+}>;
+
+type RunSaveDocumentV1 = Readonly<{
+  saveSchemaVersion: typeof RUN_SAVE_SCHEMA_VERSION;
+  simulationSchemaVersion: typeof SIMULATION_SCHEMA_VERSION;
+  run: Readonly<{
+    seed: number;
+    state: SerializedGameState;
+    environment: SerializedEnvironment;
+    draft: SerializedDecision;
+  }>;
+}>;
+
+type PersistenceErrorCode =
+  | "invalid-json"
+  | "invalid-save"
+  | "unsupported-save-version"
+  | "unsupported-simulation-version"
+  | "storage-unavailable"
+  | "storage-failed";
+
+export class RunPersistenceError extends Error {
+  readonly code: PersistenceErrorCode;
+
+  constructor(code: PersistenceErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RunPersistenceError";
+    this.code = code;
+  }
+}
+
+const invalidSave = (path: string, message: string): never => {
+  throw new RunPersistenceError("invalid-save", `${path}: ${message}`);
+};
+
+const asRecord = (value: unknown, path: string): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalidSave(path, "expected an object");
+  }
+  return value as Record<string, unknown>;
+};
+
+const asSafeInteger = (value: unknown, path: string): number => {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    return invalidSave(path, "expected a safe integer");
+  }
+  return value;
+};
+
+const asNonNegativeInteger = (value: unknown, path: string): number => {
+  const integer = asSafeInteger(value, path);
+  if (integer < 0) return invalidSave(path, "expected a non-negative integer");
+  return integer;
+};
+
+const asString = (value: unknown, path: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    return invalidSave(path, "expected a non-empty string");
+  }
+  return value;
+};
+
+const asLiteral = <const Values extends readonly string[]>(
+  value: unknown,
+  values: Values,
+  path: string,
+): Values[number] => {
+  if (typeof value !== "string" || !values.includes(value)) {
+    return invalidSave(path, `expected one of ${values.join(", ")}`);
+  }
+  return value as Values[number];
+};
+
+const asTier = (value: unknown, path: string): ProgressionTier => {
+  const tier = asSafeInteger(value, path);
+  if (tier < 0 || tier > 4) return invalidSave(path, "expected progression tier 0 through 4");
+  return tier as ProgressionTier;
+};
+
+const parseDecision = (value: unknown, path: string): DayDecision => {
+  const record = asRecord(value, path);
+  return Object.freeze({
+    glasses: glassCount(asNonNegativeInteger(record["glasses"], `${path}.glasses`)),
+    signs: signCount(asNonNegativeInteger(record["signs"], `${path}.signs`)),
+    price: moneyCents(asNonNegativeInteger(record["price"], `${path}.price`)),
+  });
+};
+
+const parseEnvironment = (value: unknown, path: string): DayEnvironment => {
+  const record = asRecord(value, path);
+  const weather = asRecord(record["weather"], `${path}.weather`);
+  const sentiment = asRecord(record["sentiment"], `${path}.sentiment`);
+  const event = asRecord(record["event"], `${path}.event`);
+
+  return Object.freeze({
+    weather: Object.freeze({
+      kind: asLiteral(weather["kind"], weatherKinds, `${path}.weather.kind`),
+      demandMultiplier: basisPoints(
+        asNonNegativeInteger(weather["demandMultiplier"], `${path}.weather.demandMultiplier`),
+      ),
+    }),
+    sentiment: Object.freeze({
+      kind: asLiteral(sentiment["kind"], sentimentKinds, `${path}.sentiment.kind`),
+      demandMultiplier: basisPoints(
+        asNonNegativeInteger(
+          sentiment["demandMultiplier"],
+          `${path}.sentiment.demandMultiplier`,
+        ),
+      ),
+    }),
+    event: Object.freeze({
+      kind: asLiteral(event["kind"], eventKinds, `${path}.event.kind`),
+      demandMultiplier: basisPoints(
+        asNonNegativeInteger(event["demandMultiplier"], `${path}.event.demandMultiplier`),
+      ),
+    }),
+  });
+};
+
+const parseLedgerLine = (value: unknown, path: string): LedgerLine => {
+  const record = asRecord(value, path);
+  return Object.freeze({
+    kind: asLiteral(record["kind"], ledgerLineKinds, `${path}.kind`),
+    label: asString(record["label"], `${path}.label`),
+    amount: moneyCents(asNonNegativeInteger(record["amount"], `${path}.amount`)),
+    direction: asLiteral(record["direction"], directions, `${path}.direction`),
+  });
+};
+
+const parseLedgerEntry = (value: unknown, path: string): DailyLedgerEntry => {
+  const record = asRecord(value, path);
+  const linesValue = record["lines"];
+  if (!Array.isArray(linesValue)) return invalidSave(`${path}.lines`, "expected an array");
+
+  return Object.freeze({
+    day: dayNumber(asSafeInteger(record["day"], `${path}.day`)),
+    tier: asTier(record["tier"], `${path}.tier`),
+    decision: parseDecision(record["decision"], `${path}.decision`),
+    environment: parseEnvironment(record["environment"], `${path}.environment`),
+    potentialDemand: glassCount(
+      asNonNegativeInteger(record["potentialDemand"], `${path}.potentialDemand`),
+    ),
+    sold: glassCount(asNonNegativeInteger(record["sold"], `${path}.sold`)),
+    revenue: moneyCents(asNonNegativeInteger(record["revenue"], `${path}.revenue`)),
+    financeIncome: moneyCents(
+      asNonNegativeInteger(record["financeIncome"], `${path}.financeIncome`),
+    ),
+    expenses: moneyCents(asNonNegativeInteger(record["expenses"], `${path}.expenses`)),
+    net: signedMoneyCents(asSafeInteger(record["net"], `${path}.net`)),
+    cashDelta: signedMoneyCents(asSafeInteger(record["cashDelta"], `${path}.cashDelta`)),
+    borrowed: moneyCents(asNonNegativeInteger(record["borrowed"], `${path}.borrowed`)),
+    repaid: moneyCents(asNonNegativeInteger(record["repaid"], `${path}.repaid`)),
+    endingCash: moneyCents(
+      asNonNegativeInteger(record["endingCash"], `${path}.endingCash`),
+    ),
+    endingLoanBalance: moneyCents(
+      asNonNegativeInteger(record["endingLoanBalance"], `${path}.endingLoanBalance`),
+    ),
+    lines: Object.freeze(
+      linesValue.map((line, index) => parseLedgerLine(line, `${path}.lines[${String(index)}]`)),
+    ),
+  });
+};
+
+const parseGameState = (value: unknown, path: string): GameState => {
+  const record = asRecord(value, path);
+  const ledgerValue = record["ledger"];
+  if (!Array.isArray(ledgerValue)) return invalidSave(`${path}.ledger`, "expected an array");
+
+  const state = Object.freeze({
+    day: dayNumber(asSafeInteger(record["day"], `${path}.day`)),
+    cash: moneyCents(asNonNegativeInteger(record["cash"], `${path}.cash`)),
+    loanBalance: moneyCents(
+      asNonNegativeInteger(record["loanBalance"], `${path}.loanBalance`),
+    ),
+    unitCost: moneyCents(asNonNegativeInteger(record["unitCost"], `${path}.unitCost`)),
+    signCost: moneyCents(asNonNegativeInteger(record["signCost"], `${path}.signCost`)),
+    tier: asTier(record["tier"], `${path}.tier`),
+    ledger: Object.freeze(
+      ledgerValue.map((entry, index) =>
+        parseLedgerEntry(entry, `${path}.ledger[${String(index)}]`),
+      ),
+    ),
+  }) satisfies GameState;
+
+  if (state.ledger.length !== Number(state.day) - 1) {
+    return invalidSave(
+      `${path}.ledger`,
+      "ledger length must equal the number of completed days",
+    );
+  }
+
+  state.ledger.forEach((entry, index) => {
+    if (Number(entry.day) !== index + 1) {
+      invalidSave(`${path}.ledger[${String(index)}].day`, "ledger days must be contiguous");
+    }
+  });
+
+  const lastEntry = state.ledger.at(-1);
+  if (lastEntry !== undefined) {
+    if (Number(lastEntry.endingCash) !== Number(state.cash)) {
+      return invalidSave(`${path}.cash`, "must match the last ledger entry ending cash");
+    }
+    if (Number(lastEntry.endingLoanBalance) !== Number(state.loanBalance)) {
+      return invalidSave(
+        `${path}.loanBalance`,
+        "must match the last ledger entry ending loan balance",
+      );
+    }
+  }
+
+  return state;
+};
+
+const serializeDecision = (decision: DayDecision): SerializedDecision =>
+  Object.freeze({
+    glasses: Number(decision.glasses),
+    signs: Number(decision.signs),
+    price: Number(decision.price),
+  });
+
+const serializeEnvironment = (environment: DayEnvironment): SerializedEnvironment =>
+  Object.freeze({
+    weather: Object.freeze({
+      kind: environment.weather.kind,
+      demandMultiplier: Number(environment.weather.demandMultiplier),
+    }),
+    sentiment: Object.freeze({
+      kind: environment.sentiment.kind,
+      demandMultiplier: Number(environment.sentiment.demandMultiplier),
+    }),
+    event: Object.freeze({
+      kind: environment.event.kind,
+      demandMultiplier: Number(environment.event.demandMultiplier),
+    }),
+  });
+
+const serializeLedgerLine = (line: LedgerLine): SerializedLedgerLine =>
+  Object.freeze({
+    kind: line.kind,
+    label: line.label,
+    amount: Number(line.amount),
+    direction: line.direction,
+  });
+
+const serializeLedgerEntry = (entry: DailyLedgerEntry): SerializedLedgerEntry =>
+  Object.freeze({
+    day: Number(entry.day),
+    tier: entry.tier,
+    decision: serializeDecision(entry.decision),
+    environment: serializeEnvironment(entry.environment),
+    potentialDemand: Number(entry.potentialDemand),
+    sold: Number(entry.sold),
+    revenue: Number(entry.revenue),
+    financeIncome: Number(entry.financeIncome),
+    expenses: Number(entry.expenses),
+    net: Number(entry.net),
+    cashDelta: Number(entry.cashDelta),
+    borrowed: Number(entry.borrowed),
+    repaid: Number(entry.repaid),
+    endingCash: Number(entry.endingCash),
+    endingLoanBalance: Number(entry.endingLoanBalance),
+    lines: Object.freeze(entry.lines.map(serializeLedgerLine)),
+  });
+
+const serializeGameState = (state: GameState): SerializedGameState =>
+  Object.freeze({
+    day: Number(state.day),
+    cash: Number(state.cash),
+    loanBalance: Number(state.loanBalance),
+    unitCost: Number(state.unitCost),
+    signCost: Number(state.signCost),
+    tier: state.tier,
+    ledger: Object.freeze(state.ledger.map(serializeLedgerEntry)),
+  });
+
+export const createRunSaveDocument = (snapshot: RunSnapshot): RunSaveDocumentV1 =>
+  Object.freeze({
+    saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION,
+    simulationSchemaVersion: SIMULATION_SCHEMA_VERSION,
+    run: Object.freeze({
+      seed: Number(snapshot.seed),
+      state: serializeGameState(snapshot.state),
+      environment: serializeEnvironment(snapshot.environment),
+      draft: serializeDecision(snapshot.draft),
+    }),
+  });
+
+const migrateVersionZero = (value: Record<string, unknown>): RunSaveDocumentV1 => {
+  const simulationSchemaVersion = asSafeInteger(
+    value["simulationSchemaVersion"],
+    "simulationSchemaVersion",
+  );
+
+  return Object.freeze({
+    saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION,
+    simulationSchemaVersion: simulationSchemaVersion as typeof SIMULATION_SCHEMA_VERSION,
+    run: Object.freeze({
+      seed: asNonNegativeInteger(value["seed"], "seed"),
+      state: value["state"] as SerializedGameState,
+      environment: value["environment"] as SerializedEnvironment,
+      draft: Object.freeze({ glasses: 20, signs: 1, price: 10 }),
+    }),
+  });
+};
+
+export const migrateRunSaveDocument = (value: unknown): unknown => {
+  const record = asRecord(value, "save");
+  const rawVersion = record["saveSchemaVersion"] ?? record["schemaVersion"];
+  const version = asSafeInteger(rawVersion, "saveSchemaVersion");
+
+  if (version > RUN_SAVE_SCHEMA_VERSION) {
+    throw new RunPersistenceError(
+      "unsupported-save-version",
+      `Save schema version ${String(version)} is newer than supported version ${String(RUN_SAVE_SCHEMA_VERSION)}.`,
+    );
+  }
+
+  if (version === 0) return migrateVersionZero(record);
+  if (version === RUN_SAVE_SCHEMA_VERSION) return record;
+
+  throw new RunPersistenceError(
+    "unsupported-save-version",
+    `Save schema version ${String(version)} is not supported.`,
+  );
+};
+
+export const decodeRunSaveDocument = (value: unknown): RunSnapshot => {
+  const migrated = asRecord(migrateRunSaveDocument(value), "save");
+  const saveSchemaVersion = asSafeInteger(
+    migrated["saveSchemaVersion"],
+    "save.saveSchemaVersion",
+  );
+  if (saveSchemaVersion !== RUN_SAVE_SCHEMA_VERSION) {
+    throw new RunPersistenceError(
+      "unsupported-save-version",
+      `Save schema version ${String(saveSchemaVersion)} is not supported.`,
+    );
+  }
+
+  const simulationSchemaVersion = asSafeInteger(
+    migrated["simulationSchemaVersion"],
+    "save.simulationSchemaVersion",
+  );
+  if (simulationSchemaVersion !== SIMULATION_SCHEMA_VERSION) {
+    throw new RunPersistenceError(
+      "unsupported-simulation-version",
+      `Save uses simulation schema ${String(simulationSchemaVersion)}; this build requires ${String(SIMULATION_SCHEMA_VERSION)}.`,
+    );
+  }
+
+  const run = asRecord(migrated["run"], "save.run");
+  return Object.freeze({
+    seed: seed(asNonNegativeInteger(run["seed"], "save.run.seed")),
+    state: parseGameState(run["state"], "save.run.state"),
+    environment: parseEnvironment(run["environment"], "save.run.environment"),
+    draft: parseDecision(run["draft"], "save.run.draft"),
+  });
+};
+
+export const exportRunSnapshot = (snapshot: RunSnapshot): string =>
+  `${JSON.stringify(createRunSaveDocument(snapshot), null, 2)}\n`;
+
+export const importRunSnapshot = (document: string): RunSnapshot => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(document) as unknown;
+  } catch (error) {
+    throw new RunPersistenceError("invalid-json", "Run file is not valid JSON.", { cause: error });
+  }
+  return decodeRunSaveDocument(parsed);
+};
+
+const requestResult = <Result>(request: IDBRequest<Result>): Promise<Result> =>
+  new Promise((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result), { once: true });
+    request.addEventListener(
+      "error",
+      () => reject(request.error ?? new Error("IndexedDB request failed.")),
+      { once: true },
+    );
+  });
+
+const transactionComplete = (transaction: IDBTransaction): Promise<void> =>
+  new Promise((resolve, reject) => {
+    transaction.addEventListener("complete", () => resolve(), { once: true });
+    transaction.addEventListener(
+      "abort",
+      () => reject(transaction.error ?? new Error("IndexedDB transaction was aborted.")),
+      { once: true },
+    );
+    transaction.addEventListener(
+      "error",
+      () => reject(transaction.error ?? new Error("IndexedDB transaction failed.")),
+      { once: true },
+    );
+  });
+
+const openDatabase = async (): Promise<IDBDatabase> => {
+  if (!("indexedDB" in globalThis)) {
+    throw new RunPersistenceError(
+      "storage-unavailable",
+      "IndexedDB is unavailable in this browser context.",
+    );
+  }
+
+  try {
+    const request = globalThis.indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    request.addEventListener("upgradeneeded", () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(RUN_STORE_NAME)) {
+        database.createObjectStore(RUN_STORE_NAME);
+      }
+    });
+    return await requestResult(request);
+  } catch (error) {
+    if (error instanceof RunPersistenceError) throw error;
+    throw new RunPersistenceError("storage-failed", "Unable to open browser run storage.", {
+      cause: error,
+    });
+  }
+};
+
+export const saveCurrentRun = async (snapshot: RunSnapshot): Promise<void> => {
+  const database = await openDatabase();
+  try {
+    const transaction = database.transaction(RUN_STORE_NAME, "readwrite");
+    transaction.objectStore(RUN_STORE_NAME).put(exportRunSnapshot(snapshot), CURRENT_RUN_KEY);
+    await transactionComplete(transaction);
+  } catch (error) {
+    throw new RunPersistenceError("storage-failed", "Unable to save the current run.", {
+      cause: error,
+    });
+  } finally {
+    database.close();
+  }
+};
+
+export const loadCurrentRun = async (): Promise<RunSnapshot | null> => {
+  const database = await openDatabase();
+  try {
+    const transaction = database.transaction(RUN_STORE_NAME, "readonly");
+    const stored = await requestResult(
+      transaction.objectStore(RUN_STORE_NAME).get(CURRENT_RUN_KEY),
+    );
+    await transactionComplete(transaction);
+    if (stored === undefined) return null;
+    if (typeof stored !== "string") return invalidSave("browser storage", "expected a text run document");
+    return importRunSnapshot(stored);
+  } catch (error) {
+    if (error instanceof RunPersistenceError) throw error;
+    throw new RunPersistenceError("storage-failed", "Unable to load the current run.", {
+      cause: error,
+    });
+  } finally {
+    database.close();
+  }
+};
+
+export const clearCurrentRun = async (): Promise<void> => {
+  const database = await openDatabase();
+  try {
+    const transaction = database.transaction(RUN_STORE_NAME, "readwrite");
+    transaction.objectStore(RUN_STORE_NAME).delete(CURRENT_RUN_KEY);
+    await transactionComplete(transaction);
+  } catch (error) {
+    throw new RunPersistenceError("storage-failed", "Unable to clear the current run.", {
+      cause: error,
+    });
+  } finally {
+    database.close();
+  }
+};

--- a/apps/web/src/persistence.ts
+++ b/apps/web/src/persistence.ts
@@ -169,7 +169,7 @@ const asLiteral = <const Values extends readonly string[]>(
   if (typeof value !== "string" || !values.includes(value)) {
     return invalidSave(path, `expected one of ${values.join(", ")}`);
   }
-  return value as Values[number];
+  return value;
 };
 
 const asTier = (value: unknown, path: string): ProgressionTier => {
@@ -474,25 +474,43 @@ export const importRunSnapshot = (document: string): RunSnapshot => {
 
 const requestResult = <Result>(request: IDBRequest<Result>): Promise<Result> =>
   new Promise((resolve, reject) => {
-    request.addEventListener("success", () => resolve(request.result), { once: true });
+    request.addEventListener(
+      "success",
+      () => {
+        resolve(request.result);
+      },
+      { once: true },
+    );
     request.addEventListener(
       "error",
-      () => reject(request.error ?? new Error("IndexedDB request failed.")),
+      () => {
+        reject(request.error ?? new Error("IndexedDB request failed."));
+      },
       { once: true },
     );
   });
 
 const transactionComplete = (transaction: IDBTransaction): Promise<void> =>
   new Promise((resolve, reject) => {
-    transaction.addEventListener("complete", () => resolve(), { once: true });
+    transaction.addEventListener(
+      "complete",
+      () => {
+        resolve();
+      },
+      { once: true },
+    );
     transaction.addEventListener(
       "abort",
-      () => reject(transaction.error ?? new Error("IndexedDB transaction was aborted.")),
+      () => {
+        reject(transaction.error ?? new Error("IndexedDB transaction was aborted."));
+      },
       { once: true },
     );
     transaction.addEventListener(
       "error",
-      () => reject(transaction.error ?? new Error("IndexedDB transaction failed.")),
+      () => {
+        reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+      },
       { once: true },
     );
   });
@@ -541,7 +559,7 @@ export const loadCurrentRun = async (): Promise<RunSnapshot | null> => {
   const database = await openDatabase();
   try {
     const transaction = database.transaction(RUN_STORE_NAME, "readonly");
-    const stored = await requestResult(
+    const stored = await requestResult<unknown>(
       transaction.objectStore(RUN_STORE_NAME).get(CURRENT_RUN_KEY),
     );
     await transactionComplete(transaction);

--- a/apps/web/test/persistence.test.ts
+++ b/apps/web/test/persistence.test.ts
@@ -88,8 +88,8 @@ describe("run persistence", () => {
       });
       throw new Error("expected decode to fail");
     } catch (error) {
-      expect(error).toBeInstanceOf(RunPersistenceError);
-      expect((error as RunPersistenceError).code).toBe("unsupported-save-version");
+      if (!(error instanceof RunPersistenceError)) throw error;
+      expect(error.code).toBe("unsupported-save-version");
     }
   });
 
@@ -106,16 +106,21 @@ describe("run persistence", () => {
 
   it("rejects corrupt ledger history instead of recomputing it", () => {
     const document = createRunSaveDocument(createFixture());
-    const corrupt = structuredClone(document) as unknown as {
-      run: { state: { cash: number } };
+    const corrupt = {
+      ...document,
+      run: {
+        ...document.run,
+        state: {
+          ...document.run.state,
+          cash: document.run.state.cash + 1,
+        },
+      },
     };
-    corrupt.run.state.cash += 1;
 
     expect(() => decodeRunSaveDocument(corrupt)).toThrow(/ending cash/);
   });
 
   it("rejects invalid JSON before it reaches domain parsing", () => {
-    expect(() => importRunSnapshot("{not-json}"))
-      .toThrowError(/not valid JSON/);
+    expect(() => importRunSnapshot("{not-json}")).toThrowError(/not valid JSON/);
   });
 });

--- a/apps/web/test/persistence.test.ts
+++ b/apps/web/test/persistence.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SIMULATION_SCHEMA_VERSION,
+  createInitialState,
+  glassCount,
+  moneyCents,
+  neutralEnvironment,
+  seed,
+  signCount,
+  simulateDay,
+} from "@lemonade/simulation";
+
+import {
+  RUN_SAVE_SCHEMA_VERSION,
+  RunPersistenceError,
+  createRunSaveDocument,
+  decodeRunSaveDocument,
+  exportRunSnapshot,
+  importRunSnapshot,
+  type RunSnapshot,
+} from "../src/persistence.js";
+
+const createFixture = (): RunSnapshot => {
+  const decision = Object.freeze({
+    glasses: glassCount(20),
+    signs: signCount(1),
+    price: moneyCents(10),
+  });
+  const resolution = simulateDay(createInitialState(), decision, neutralEnvironment());
+
+  return Object.freeze({
+    seed: seed(0x1e_ad_2026),
+    state: resolution.nextState,
+    environment: neutralEnvironment(),
+    draft: decision,
+  });
+};
+
+describe("run persistence", () => {
+  it("round-trips a complete deterministic run snapshot", () => {
+    const snapshot = createFixture();
+    const restored = importRunSnapshot(exportRunSnapshot(snapshot));
+
+    expect(restored).toEqual(snapshot);
+    expect(restored.state.ledger).toHaveLength(1);
+    expect(restored.state.ledger[0]).toEqual(snapshot.state.ledger[0]);
+  });
+
+  it("writes explicit save and simulation schema versions", () => {
+    const document = createRunSaveDocument(createFixture());
+
+    expect(document.saveSchemaVersion).toBe(RUN_SAVE_SCHEMA_VERSION);
+    expect(document.simulationSchemaVersion).toBe(SIMULATION_SCHEMA_VERSION);
+  });
+
+  it("migrates the pre-versioned prototype shape to schema version 1", () => {
+    const snapshot = createFixture();
+    const legacy = {
+      schemaVersion: 0,
+      simulationSchemaVersion: SIMULATION_SCHEMA_VERSION,
+      seed: Number(snapshot.seed),
+      state: snapshot.state,
+      environment: snapshot.environment,
+    };
+
+    const restored = decodeRunSaveDocument(legacy);
+
+    expect(restored.state).toEqual(snapshot.state);
+    expect(restored.environment).toEqual(snapshot.environment);
+    expect(restored.draft).toEqual({ glasses: 20, signs: 1, price: 10 });
+  });
+
+  it("rejects future save schemas with an actionable error", () => {
+    const document = createRunSaveDocument(createFixture());
+
+    expect(() =>
+      decodeRunSaveDocument({
+        ...document,
+        saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION + 1,
+      }),
+    ).toThrowError(RunPersistenceError);
+
+    try {
+      decodeRunSaveDocument({
+        ...document,
+        saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION + 1,
+      });
+      throw new Error("expected decode to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RunPersistenceError);
+      expect((error as RunPersistenceError).code).toBe("unsupported-save-version");
+    }
+  });
+
+  it("rejects saves from an incompatible simulation schema", () => {
+    const document = createRunSaveDocument(createFixture());
+
+    expect(() =>
+      decodeRunSaveDocument({
+        ...document,
+        simulationSchemaVersion: SIMULATION_SCHEMA_VERSION + 1,
+      }),
+    ).toThrow(/requires/);
+  });
+
+  it("rejects corrupt ledger history instead of recomputing it", () => {
+    const document = createRunSaveDocument(createFixture());
+    const corrupt = structuredClone(document) as unknown as {
+      run: { state: { cash: number } };
+    };
+    corrupt.run.state.cash += 1;
+
+    expect(() => decodeRunSaveDocument(corrupt)).toThrow(/ending cash/);
+  });
+
+  it("rejects invalid JSON before it reaches domain parsing", () => {
+    expect(() => importRunSnapshot("{not-json}"))
+      .toThrowError(/not valid JSON/);
+  });
+});

--- a/apps/web/test/persistence.test.ts
+++ b/apps/web/test/persistence.test.ts
@@ -79,7 +79,7 @@ describe("run persistence", () => {
         ...document,
         saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION + 1,
       }),
-    ).toThrowError(RunPersistenceError);
+    ).toThrow(RunPersistenceError);
 
     try {
       decodeRunSaveDocument({
@@ -121,6 +121,6 @@ describe("run persistence", () => {
   });
 
   it("rejects invalid JSON before it reaches domain parsing", () => {
-    expect(() => importRunSnapshot("{not-json}")).toThrowError(/not valid JSON/);
+    expect(() => importRunSnapshot("{not-json}")).toThrow(/not valid JSON/);
   });
 });

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,79 @@
+# Run persistence contract
+
+Phase 8 introduces durable runs without making persistence part of the simulation engine.
+
+## Boundary
+
+The deterministic simulation remains storage-agnostic. Browser persistence lives at the web application boundary and consumes validated simulation values.
+
+```text
+packages/simulation
+        ^
+        |
+apps/web/src/persistence.ts
+        ^
+        |
+IndexedDB / portable JSON
+```
+
+The persistence boundary has four responsibilities:
+
+1. serialize a run into an explicit portable schema;
+2. migrate older save schemas forward when a migration is defined;
+3. validate all imported/stored data before reconstructing branded domain values;
+4. adapt the validated document to native browser storage.
+
+It must never recompute historical ledger entries from current balance rules.
+
+## Schema version 1
+
+A portable document records:
+
+- `saveSchemaVersion` — format/migration version;
+- `simulationSchemaVersion` — ruleset/domain compatibility version;
+- `run.seed` — deterministic environment-sequence identity;
+- `run.state` — current immutable game state including the full daily ledger;
+- `run.environment` — the already-selected current-day weather, sentiment, and event;
+- `run.draft` — the three current player decisions.
+
+Money remains integer cents. Counts, days, seeds, multipliers, tiers, variant discriminants, and every ledger line are validated before conversion back into simulation types.
+
+The current validator additionally checks that:
+
+- ledger length equals the number of completed days;
+- ledger day numbers are contiguous from day 1;
+- current cash equals the final ledger entry's ending cash;
+- current debt equals the final ledger entry's ending loan balance.
+
+These checks reject corrupted or internally inconsistent documents rather than attempting repair by replaying under current rules.
+
+## Save schema migration versus simulation compatibility
+
+Save-schema migration and simulation/ruleset compatibility are intentionally separate.
+
+A known older save schema may be migrated structurally into the current format. A save created against a different simulation schema is rejected unless a separate, explicit compatibility policy is implemented. This prevents a new balance model from silently changing historical outcomes.
+
+The initial migration fixture accepts the pre-versioned prototype shape (`schemaVersion: 0`) and wraps it in schema version 1 while supplying the original default three-control draft.
+
+## Browser storage
+
+The browser adapter uses IndexedDB rather than `localStorage` because a run contains structured historical data and needs an explicit storage version. One key, `current`, owns the active run in the first implementation.
+
+Storage contains the same JSON text used for portable export. Loading therefore always traverses the same migration and validation path as importing a file; browser storage is not trusted merely because the application wrote it previously.
+
+## Portable import/export
+
+`exportRunSnapshot()` emits human-inspectable JSON with a trailing newline. `importRunSnapshot()` parses, migrates, validates, and reconstructs the run. This format is independent of a UI framework and is suitable for a later native file adapter without changing simulation APIs.
+
+## Next integration slice
+
+The web controller should next:
+
+- restore the current run before constructing the primary day UI;
+- save at deterministic state-transition boundaries;
+- reconstruct the environment RNG position from the stored seed/day under the matching simulation schema;
+- expose explicit export/import/reset actions without adding daily operating controls;
+- surface storage/import failures as accessible actionable messages;
+- add Playwright coverage proving a run survives reload and portable import into a clean browser context.
+
+A future `packages/persistence` extraction is appropriate if another runtime (for example Tauri) needs the same schema/migration layer. Until then, keeping the boundary in the only consuming runtime avoids creating a workspace package solely for indirection.


### PR DESCRIPTION
## Scope
Begins Phase 8 / #21 with the persistence foundation while keeping the deterministic simulation storage-agnostic.

- adds explicit save schema v1 and simulation-schema compatibility checks
- serializes/deserializes the full immutable ledger without recomputation
- validates untrusted persisted/imported data before reconstructing branded domain values
- adds a schema-0 -> schema-1 migration fixture
- adds portable JSON import/export helpers
- adds a native IndexedDB current-run adapter with no new runtime dependency
- documents the storage boundary and next integration slice
- adds unit coverage for round-trip, migration, future-version rejection, incompatible rulesets, corrupt ledger history, and invalid JSON

This deliberately does not yet wire persistence into `LemonadeApp`; the next slice will restore before application construction, persist at state transitions, reconstruct RNG position from seed/day, add explicit import/export/reset UI, and certify reload/import behavior with Playwright.

Closes no issue yet; #21 remains the parent implementation issue.

Refs #21