### PR TITLE
feat: integrate Phase 8 browser persistence

### DIFF
--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -3,7 +3,6 @@ import {
   availableOperatingFunds,
   createInitialState,
   createSeededRandom,
-  dayNumber,
   financeRulesForTier,
   generateEnvironment,
   glassCount,
@@ -13,16 +12,25 @@ import {
   signCount,
   simulateDay,
   type DayEnvironment,
-  type DayResolution,
   type GameState,
+  type RandomSource,
+  type Seed,
 } from "@lemonade/simulation";
 import { renderLedgerHistory } from "@lemonade/ui";
 
+import {
+  RunPersistenceError,
+  clearCurrentRun,
+  exportRunSnapshot,
+  importRunSnapshot,
+  restoreEnvironmentRandom,
+  saveCurrentRun,
+  type RunPhase,
+  type RunSnapshot,
+} from "./persistence.js";
 import { createLemonsvilleSceneView, type LemonsvilleSceneView } from "./scene.js";
 
-type Phase =
-  | Readonly<{ kind: "deciding" }>
-  | Readonly<{ kind: "report"; resolution: DayResolution }>;
+const DEFAULT_RUN_SEED = seed(0x1e_ad_2026);
 
 const weatherLabel: Record<DayEnvironment["weather"]["kind"], string> = {
   sunny: "Sunny",
@@ -91,6 +99,28 @@ const financeSummary = (state: GameState): string => {
     : parts.join(" · ");
 };
 
+const persistenceMessage = (error: unknown): string =>
+  error instanceof RunPersistenceError
+    ? error.message
+    : "Run storage failed unexpectedly. Export your run before leaving this page.";
+
+export const createFreshRunSnapshot = (): RunSnapshot => {
+  const state = createInitialState();
+  const random = createSeededRandom(DEFAULT_RUN_SEED);
+  const environment = generateEnvironment(state.day, random);
+  return Object.freeze({
+    seed: DEFAULT_RUN_SEED,
+    state,
+    environment,
+    draft: Object.freeze({
+      glasses: glassCount(20),
+      signs: signCount(1),
+      price: moneyCents(10),
+    }),
+    phase: Object.freeze({ kind: "deciding" }),
+  });
+};
+
 const SHELL_MARKUP = `
   <main class="game-shell">
     <header class="topline">
@@ -104,6 +134,20 @@ const SHELL_MARKUP = `
         <div id="status-debt-group" hidden><dt>Debt</dt><dd id="status-debt"></dd></div>
       </dl>
     </header>
+
+    <section class="run-tools" aria-label="Run data">
+      <div class="run-tools-copy">
+        <p class="eyebrow">Run data</p>
+        <p id="run-status" class="run-status" role="status" aria-live="polite"></p>
+        <p id="run-error" class="inline-error" role="alert" hidden></p>
+      </div>
+      <div class="run-actions">
+        <button id="export-run" class="utility-button" type="button">Export run</button>
+        <button id="import-run" class="utility-button" type="button">Import run</button>
+        <input id="import-file" type="file" accept="application/json,.json" hidden />
+        <button id="reset-run" class="utility-button utility-button-danger" type="button">Reset run</button>
+      </div>
+    </section>
 
     <section class="conditions" aria-labelledby="conditions-title">
       <div>
@@ -214,6 +258,12 @@ type AppElements = Readonly<{
   statusCash: HTMLElement;
   statusDebtGroup: HTMLElement;
   statusDebt: HTMLElement;
+  runStatus: HTMLElement;
+  runError: HTMLElement;
+  exportRun: HTMLButtonElement;
+  importRun: HTMLButtonElement;
+  importFile: HTMLInputElement;
+  resetRun: HTMLButtonElement;
   conditionWeather: HTMLElement;
   conditionSentiment: HTMLElement;
   conditionProduction: HTMLElement;
@@ -255,6 +305,12 @@ const collectElements = (root: HTMLElement): AppElements =>
     statusCash: requireElement(root, "#status-cash", HTMLElement),
     statusDebtGroup: requireElement(root, "#status-debt-group", HTMLElement),
     statusDebt: requireElement(root, "#status-debt", HTMLElement),
+    runStatus: requireElement(root, "#run-status", HTMLElement),
+    runError: requireElement(root, "#run-error", HTMLElement),
+    exportRun: requireElement(root, "#export-run", HTMLButtonElement),
+    importRun: requireElement(root, "#import-run", HTMLButtonElement),
+    importFile: requireElement(root, "#import-file", HTMLInputElement),
+    resetRun: requireElement(root, "#reset-run", HTMLButtonElement),
     conditionWeather: requireElement(root, "#condition-weather", HTMLElement),
     conditionSentiment: requireElement(root, "#condition-sentiment", HTMLElement),
     conditionProduction: requireElement(root, "#condition-production", HTMLElement),
@@ -293,21 +349,48 @@ const collectElements = (root: HTMLElement): AppElements =>
 const numericInputValue = (input: HTMLInputElement, fallback: number): number =>
   Number.isFinite(input.valueAsNumber) ? input.valueAsNumber : fallback;
 
+export type LemonadeAppOptions = Readonly<{
+  persistenceEnabled: boolean;
+  initialPersistenceError: string | null;
+}>;
+
+const DEFAULT_OPTIONS: LemonadeAppOptions = Object.freeze({
+  persistenceEnabled: true,
+  initialPersistenceError: null,
+});
+
 export class LemonadeApp {
   readonly #elements: AppElements;
-  readonly #random = createSeededRandom(seed(0x1e_ad_2026));
+  readonly #runSeed: Seed;
+  readonly #random: RandomSource;
   readonly #audio = createProceduralAudioEngine();
   readonly #scene: LemonsvilleSceneView;
+  readonly #persistenceEnabled: boolean;
 
-  #game = createInitialState();
-  #environment = generateEnvironment(dayNumber(1), this.#random);
-  #phase: Phase = Object.freeze({ kind: "deciding" });
-  #glasses = 20;
-  #signs = 1;
-  #price = 10;
+  #game: GameState;
+  #environment: DayEnvironment;
+  #phase: RunPhase;
+  #glasses: number;
+  #signs: number;
+  #price: number;
+  #saveChain: Promise<void> = Promise.resolve();
   #disposed = false;
 
-  constructor(root: HTMLElement) {
+  constructor(
+    root: HTMLElement,
+    initialRun: RunSnapshot = createFreshRunSnapshot(),
+    options: LemonadeAppOptions = DEFAULT_OPTIONS,
+  ) {
+    this.#runSeed = initialRun.seed;
+    this.#random = restoreEnvironmentRandom(initialRun);
+    this.#game = initialRun.state;
+    this.#environment = initialRun.environment;
+    this.#phase = initialRun.phase;
+    this.#glasses = Number(initialRun.draft.glasses);
+    this.#signs = Number(initialRun.draft.signs);
+    this.#price = Number(initialRun.draft.price);
+    this.#persistenceEnabled = options.persistenceEnabled;
+
     root.innerHTML = SHELL_MARKUP;
     this.#elements = collectElements(root);
     this.#scene = createLemonsvilleSceneView({
@@ -322,10 +405,24 @@ export class LemonadeApp {
     this.#elements.glasses.addEventListener("input", this.#onGlassesInput);
     this.#elements.signs.addEventListener("input", this.#onSignsInput);
     this.#elements.price.addEventListener("input", this.#onPriceInput);
+    this.#elements.exportRun.addEventListener("click", this.#onExportRun);
+    this.#elements.importRun.addEventListener("click", this.#onImportRun);
+    this.#elements.importFile.addEventListener("change", this.#onImportFileChange);
+    this.#elements.resetRun.addEventListener("click", this.#onResetRun);
     document.addEventListener("visibilitychange", this.#onVisibilityChange);
     window.addEventListener("pagehide", this.#onPageHide, { once: true });
 
+    this.#elements.importRun.disabled = !this.#persistenceEnabled;
+    this.#elements.resetRun.disabled = !this.#persistenceEnabled;
     this.#render();
+
+    if (options.initialPersistenceError !== null) {
+      this.#showPersistenceError(options.initialPersistenceError);
+    } else if (this.#persistenceEnabled) {
+      this.#queueSave("Run saved locally.");
+    } else {
+      this.#elements.runStatus.textContent = "Autosave is unavailable in this browser context.";
+    }
   }
 
   dispose(): void {
@@ -336,6 +433,10 @@ export class LemonadeApp {
     this.#elements.glasses.removeEventListener("input", this.#onGlassesInput);
     this.#elements.signs.removeEventListener("input", this.#onSignsInput);
     this.#elements.price.removeEventListener("input", this.#onPriceInput);
+    this.#elements.exportRun.removeEventListener("click", this.#onExportRun);
+    this.#elements.importRun.removeEventListener("click", this.#onImportRun);
+    this.#elements.importFile.removeEventListener("change", this.#onImportFileChange);
+    this.#elements.resetRun.removeEventListener("click", this.#onResetRun);
     document.removeEventListener("visibilitychange", this.#onVisibilityChange);
     window.removeEventListener("pagehide", this.#onPageHide);
     this.#scene.dispose();
@@ -390,6 +491,7 @@ export class LemonadeApp {
     const previousTier = this.#game.tier;
     this.#phase = Object.freeze({ kind: "report", resolution });
     this.#render();
+    this.#queueSave("Day report saved locally.");
 
     void this.#audio.enable().then((enabled) => {
       if (!enabled) return;
@@ -419,11 +521,110 @@ export class LemonadeApp {
     this.#signs = Math.min(this.#signs, limits.signs);
     this.#phase = Object.freeze({ kind: "deciding" });
     this.#render();
+    this.#queueSave("Next day saved locally.");
 
     void this.#audio.enable().then((enabled) => {
       if (enabled) this.#audio.play(weatherCue(nextEnvironment.weather.kind));
     });
   };
+
+  readonly #onExportRun = (): void => {
+    try {
+      const documentText = exportRunSnapshot(this.#snapshot());
+      const blob = new Blob([documentText], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `lemonade-run-day-${String(Number(this.#game.day))}.json`;
+      link.click();
+      window.setTimeout(() => {
+        URL.revokeObjectURL(url);
+      }, 0);
+      this.#showPersistenceStatus("Portable run exported.");
+    } catch (error) {
+      this.#showPersistenceError(persistenceMessage(error));
+    }
+  };
+
+  readonly #onImportRun = (): void => {
+    if (!this.#persistenceEnabled) return;
+    this.#elements.importFile.click();
+  };
+
+  readonly #onImportFileChange = (): void => {
+    const file = this.#elements.importFile.files?.item(0);
+    this.#elements.importFile.value = "";
+    if (file === null || file === undefined) return;
+    void this.#importFile(file);
+  };
+
+  readonly #onResetRun = (): void => {
+    if (!this.#persistenceEnabled) return;
+    const confirmed = window.confirm(
+      "Reset this run? The local run will be deleted. Export it first if you want a portable copy.",
+    );
+    if (confirmed) void this.#resetRun();
+  };
+
+  async #importFile(file: File): Promise<void> {
+    try {
+      const imported = importRunSnapshot(await file.text());
+      await this.#saveChain;
+      await saveCurrentRun(imported);
+      window.location.reload();
+    } catch (error) {
+      this.#showPersistenceError(persistenceMessage(error));
+    }
+  }
+
+  async #resetRun(): Promise<void> {
+    try {
+      await this.#saveChain;
+      await clearCurrentRun();
+      window.location.reload();
+    } catch (error) {
+      this.#showPersistenceError(persistenceMessage(error));
+    }
+  }
+
+  #snapshot(): RunSnapshot {
+    return Object.freeze({
+      seed: this.#runSeed,
+      state: this.#game,
+      environment: this.#environment,
+      draft: Object.freeze({
+        glasses: glassCount(this.#glasses),
+        signs: signCount(this.#signs),
+        price: moneyCents(this.#price),
+      }),
+      phase: this.#phase,
+    });
+  }
+
+  #queueSave(successMessage: string): void {
+    if (!this.#persistenceEnabled) return;
+    const snapshot = this.#snapshot();
+    this.#saveChain = this.#saveChain
+      .then(async () => {
+        await saveCurrentRun(snapshot);
+        if (!this.#disposed) this.#showPersistenceStatus(successMessage);
+      })
+      .catch((error: unknown) => {
+        if (!this.#disposed) this.#showPersistenceError(persistenceMessage(error));
+      });
+  }
+
+  #showPersistenceStatus(message: string): void {
+    this.#elements.runStatus.textContent = message;
+    this.#elements.runError.hidden = true;
+    this.#elements.runError.textContent = "";
+  }
+
+  #showPersistenceError(message: string): void {
+    this.#elements.runStatus.textContent = "Run storage needs attention.";
+    this.#elements.runError.textContent = message;
+    this.#elements.runError.hidden = false;
+  }
 
   #affordability(): Readonly<{ affordable: boolean; operatingFunds: number; spend: number }> {
     const fixedObligations = Number(predictableFixedObligations(this.#game));
@@ -450,7 +651,9 @@ export class LemonadeApp {
     this.#elements.statusDay.textContent = String(Number(this.#game.day));
     this.#elements.statusCash.textContent = formatMoney(Number(this.#game.cash));
     this.#elements.statusDebt.textContent = formatMoney(Number(this.#game.loanBalance));
-    this.#elements.statusDebtGroup.hidden = !(this.#game.tier >= 3 || Number(this.#game.loanBalance) > 0);
+    this.#elements.statusDebtGroup.hidden = !(
+      this.#game.tier >= 3 || Number(this.#game.loanBalance) > 0
+    );
 
     this.#elements.conditionWeather.textContent = weatherLabel[this.#environment.weather.kind];
     this.#elements.conditionSentiment.textContent = sentimentLabel[this.#environment.sentiment.kind];
@@ -474,7 +677,9 @@ export class LemonadeApp {
     this.#elements.price.value = String(this.#price);
     this.#elements.priceOutput.textContent = formatMoney(this.#price);
     this.#elements.decisionSpend.textContent = `Spend ${formatMoney(affordability.spend)} of ${formatMoney(affordability.operatingFunds)} operating funds`;
-    this.#elements.decisionSpend.className = affordability.affordable ? "spend" : "spend spend-warning";
+    this.#elements.decisionSpend.className = affordability.affordable
+      ? "spend"
+      : "spend spend-warning";
     this.#elements.decisionError.hidden = affordability.affordable;
     this.#elements.sellButton.disabled = !affordability.affordable;
   }
@@ -520,7 +725,8 @@ export class LemonadeApp {
     const phase = this.#phase;
     this.#scene.update({
       environment: this.#environment,
-      visibleSigns: phase.kind === "report" ? Number(phase.resolution.entry.decision.signs) : this.#signs,
+      visibleSigns:
+        phase.kind === "report" ? Number(phase.resolution.entry.decision.signs) : this.#signs,
       phase: phase.kind,
       sold: phase.kind === "report" ? Number(phase.resolution.entry.sold) : 0,
       prepared:

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -3,11 +3,77 @@ import "./scene.css";
 import "./history.css";
 import "./finance.css";
 
-import { LemonadeApp } from "./app.js";
+import { LemonadeApp, createFreshRunSnapshot } from "./app.js";
+import { RunPersistenceError, clearCurrentRun, loadCurrentRun } from "./persistence.js";
 
 const root = document.querySelector("#root");
 if (!(root instanceof HTMLElement)) {
   throw new TypeError("Expected #root application mount point.");
 }
 
-new LemonadeApp(root);
+const renderRecovery = (error: RunPersistenceError): void => {
+  root.innerHTML = `
+    <main class="game-shell bootstrap-shell">
+      <section class="decision-panel bootstrap-recovery" aria-labelledby="recovery-title">
+        <p class="eyebrow">Saved run recovery</p>
+        <h1 id="recovery-title">Run could not be restored</h1>
+        <p id="recovery-error" class="inline-error" role="alert"></p>
+        <p>The saved document has been left untouched. You can discard it explicitly and begin a new run.</p>
+        <button id="discard-saved-run" class="sell-button" type="button">Discard saved run and start new</button>
+      </section>
+    </main>
+  `;
+
+  const errorElement = root.querySelector("#recovery-error");
+  const discardButton = root.querySelector("#discard-saved-run");
+  if (!(errorElement instanceof HTMLElement) || !(discardButton instanceof HTMLButtonElement)) {
+    throw new TypeError("Expected saved-run recovery controls.");
+  }
+
+  errorElement.textContent = error.message;
+  discardButton.addEventListener(
+    "click",
+    () => {
+      discardButton.disabled = true;
+      void clearCurrentRun()
+        .then(() => {
+          window.location.reload();
+        })
+        .catch((clearError: unknown) => {
+          discardButton.disabled = false;
+          errorElement.textContent =
+            clearError instanceof Error
+              ? clearError.message
+              : "Unable to clear browser run storage.";
+        });
+    },
+    { once: true },
+  );
+};
+
+const start = async (): Promise<void> => {
+  try {
+    const restored = await loadCurrentRun();
+    new LemonadeApp(root, restored ?? createFreshRunSnapshot());
+  } catch (error) {
+    if (
+      error instanceof RunPersistenceError &&
+      (error.code === "storage-unavailable" || error.code === "storage-failed")
+    ) {
+      new LemonadeApp(root, createFreshRunSnapshot(), {
+        persistenceEnabled: false,
+        initialPersistenceError: error.message,
+      });
+      return;
+    }
+
+    if (error instanceof RunPersistenceError) {
+      renderRecovery(error);
+      return;
+    }
+
+    throw error;
+  }
+};
+
+void start();

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -2,6 +2,7 @@ import "./styles.css";
 import "./scene.css";
 import "./history.css";
 import "./finance.css";
+import "./persistence.css";
 
 import { LemonadeApp, createFreshRunSnapshot } from "./app.js";
 import { RunPersistenceError, clearCurrentRun, loadCurrentRun } from "./persistence.js";

--- a/apps/web/src/persistence.css
+++ b/apps/web/src/persistence.css
@@ -1,0 +1,98 @@
+.run-tools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 24px 0 18px;
+  padding: 14px 16px;
+  border: 2px solid #211d14;
+  background: rgb(255 249 228 / 88%);
+  box-shadow: 5px 5px 0 #211d14;
+}
+
+.run-tools-copy {
+  min-width: 0;
+}
+
+.run-tools .eyebrow {
+  margin-bottom: 4px;
+}
+
+.run-status {
+  color: #4f493d;
+  font-size: 0.9rem;
+}
+
+.run-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.utility-button {
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 2px solid #211d14;
+  background: #f6df8f;
+  color: #211d14;
+  box-shadow: 3px 3px 0 #211d14;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.utility-button:hover:not(:disabled) {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 #211d14;
+}
+
+.utility-button:active:not(:disabled) {
+  transform: translate(2px, 2px);
+  box-shadow: 1px 1px 0 #211d14;
+}
+
+.utility-button-danger {
+  background: #f2c2a8;
+}
+
+.utility-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.bootstrap-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding-block: 32px;
+}
+
+.bootstrap-recovery {
+  width: min(720px, 100%);
+  margin-top: 0;
+}
+
+.bootstrap-recovery h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2rem, 7vw, 4.6rem);
+}
+
+.bootstrap-recovery > p:not(.eyebrow) {
+  margin-bottom: 18px;
+  max-width: 62ch;
+}
+
+@media (max-width: 760px) {
+  .run-tools {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .run-actions {
+    justify-content: stretch;
+  }
+
+  .utility-button {
+    flex: 1 1 9rem;
+  }
+}

--- a/apps/web/src/persistence.ts
+++ b/apps/web/src/persistence.ts
@@ -1,22 +1,27 @@
 import {
   SIMULATION_SCHEMA_VERSION,
   basisPoints,
+  createSeededRandom,
   dayNumber,
+  generateEnvironment,
   glassCount,
   moneyCents,
   seed,
   signedMoneyCents,
   signCount,
+  simulateDay,
   type DayDecision,
   type DayEnvironment,
   type DailyLedgerEntry,
+  type DayResolution,
   type GameState,
   type LedgerLine,
   type ProgressionTier,
+  type RandomSource,
   type Seed,
 } from "@lemonade/simulation";
 
-export const RUN_SAVE_SCHEMA_VERSION = 1 as const;
+export const RUN_SAVE_SCHEMA_VERSION = 2 as const;
 
 const DATABASE_NAME = "lemonade";
 const DATABASE_VERSION = 1;
@@ -40,12 +45,18 @@ const weatherKinds = ["sunny", "cloudy", "hot-and-dry", "thunderstorm"] as const
 const sentimentKinds = ["very-cold", "cold", "neutral", "warm", "hot"] as const;
 const eventKinds = ["none", "street-work", "workers-buy-out"] as const;
 const directions = ["credit", "debit"] as const;
+const phaseKinds = ["deciding", "report"] as const;
+
+export type RunPhase =
+  | Readonly<{ kind: "deciding" }>
+  | Readonly<{ kind: "report"; resolution: DayResolution }>;
 
 export type RunSnapshot = Readonly<{
   seed: Seed;
   state: GameState;
   environment: DayEnvironment;
   draft: DayDecision;
+  phase: RunPhase;
 }>;
 
 type SerializedDecision = Readonly<{
@@ -101,7 +112,22 @@ type SerializedGameState = Readonly<{
   ledger: readonly SerializedLedgerEntry[];
 }>;
 
+type SerializedPhase =
+  | Readonly<{ kind: "deciding" }>
+  | Readonly<{ kind: "report"; nextState: SerializedGameState }>;
+
 type RunSaveDocumentV1 = Readonly<{
+  saveSchemaVersion: 1;
+  simulationSchemaVersion: number;
+  run: Readonly<{
+    seed: number;
+    state: unknown;
+    environment: unknown;
+    draft: unknown;
+  }>;
+}>;
+
+type RunSaveDocumentV2 = Readonly<{
   saveSchemaVersion: typeof RUN_SAVE_SCHEMA_VERSION;
   simulationSchemaVersion: typeof SIMULATION_SCHEMA_VERSION;
   run: Readonly<{
@@ -109,6 +135,7 @@ type RunSaveDocumentV1 = Readonly<{
     state: SerializedGameState;
     environment: SerializedEnvironment;
     draft: SerializedDecision;
+    phase: SerializedPhase;
   }>;
 }>;
 
@@ -375,7 +402,15 @@ const serializeGameState = (state: GameState): SerializedGameState =>
     ledger: Object.freeze(state.ledger.map(serializeLedgerEntry)),
   });
 
-export const createRunSaveDocument = (snapshot: RunSnapshot): RunSaveDocumentV1 =>
+const serializePhase = (phase: RunPhase): SerializedPhase =>
+  phase.kind === "deciding"
+    ? Object.freeze({ kind: "deciding" })
+    : Object.freeze({
+        kind: "report",
+        nextState: serializeGameState(phase.resolution.nextState),
+      });
+
+export const createRunSaveDocument = (snapshot: RunSnapshot): RunSaveDocumentV2 =>
   Object.freeze({
     saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION,
     simulationSchemaVersion: SIMULATION_SCHEMA_VERSION,
@@ -384,6 +419,7 @@ export const createRunSaveDocument = (snapshot: RunSnapshot): RunSaveDocumentV1 
       state: serializeGameState(snapshot.state),
       environment: serializeEnvironment(snapshot.environment),
       draft: serializeDecision(snapshot.draft),
+      phase: serializePhase(snapshot.phase),
     }),
   });
 
@@ -394,15 +430,27 @@ const migrateVersionZero = (value: Record<string, unknown>): RunSaveDocumentV1 =
   );
 
   return Object.freeze({
-    saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION,
-    simulationSchemaVersion: simulationSchemaVersion as typeof SIMULATION_SCHEMA_VERSION,
+    saveSchemaVersion: 1,
+    simulationSchemaVersion,
     run: Object.freeze({
       seed: asNonNegativeInteger(value["seed"], "seed"),
-      state: value["state"] as SerializedGameState,
-      environment: value["environment"] as SerializedEnvironment,
+      state: value["state"],
+      environment: value["environment"],
       draft: Object.freeze({ glasses: 20, signs: 1, price: 10 }),
     }),
   });
+};
+
+const migrateVersionOne = (value: Record<string, unknown>): Record<string, unknown> => {
+  const run = asRecord(value["run"], "save.run");
+  return {
+    ...value,
+    saveSchemaVersion: RUN_SAVE_SCHEMA_VERSION,
+    run: {
+      ...run,
+      phase: Object.freeze({ kind: "deciding" }),
+    },
+  };
 };
 
 export const migrateRunSaveDocument = (value: unknown): unknown => {
@@ -417,13 +465,74 @@ export const migrateRunSaveDocument = (value: unknown): unknown => {
     );
   }
 
-  if (version === 0) return migrateVersionZero(record);
+  if (version === 0) {
+    return migrateVersionOne(asRecord(migrateVersionZero(record), "save"));
+  }
+  if (version === 1) return migrateVersionOne(record);
   if (version === RUN_SAVE_SCHEMA_VERSION) return record;
 
   throw new RunPersistenceError(
     "unsupported-save-version",
     `Save schema version ${String(version)} is not supported.`,
   );
+};
+
+const serializedStatesEqual = (left: GameState, right: GameState): boolean =>
+  JSON.stringify(serializeGameState(left)) === JSON.stringify(serializeGameState(right));
+
+const parsePhase = (
+  value: unknown,
+  state: GameState,
+  environment: DayEnvironment,
+  draft: DayDecision,
+  path: string,
+): RunPhase => {
+  const record = asRecord(value, path);
+  const kind = asLiteral(record["kind"], phaseKinds, `${path}.kind`);
+  if (kind === "deciding") return Object.freeze({ kind: "deciding" });
+
+  const nextState = parseGameState(record["nextState"], `${path}.nextState`);
+  const expected = simulateDay(state, draft, environment);
+  if (!serializedStatesEqual(nextState, expected.nextState)) {
+    return invalidSave(path, "report state does not match the deterministic day resolution");
+  }
+
+  const entry = nextState.ledger.at(-1);
+  if (entry === undefined) return invalidSave(path, "report state must contain the resolved day");
+
+  return Object.freeze({
+    kind: "report",
+    resolution: Object.freeze({ previousState: state, nextState, entry }),
+  });
+};
+
+const environmentsEqual = (left: DayEnvironment, right: DayEnvironment): boolean =>
+  left.weather.kind === right.weather.kind &&
+  Number(left.weather.demandMultiplier) === Number(right.weather.demandMultiplier) &&
+  left.sentiment.kind === right.sentiment.kind &&
+  Number(left.sentiment.demandMultiplier) === Number(right.sentiment.demandMultiplier) &&
+  left.event.kind === right.event.kind &&
+  Number(left.event.demandMultiplier) === Number(right.event.demandMultiplier);
+
+export const restoreEnvironmentRandom = (
+  snapshot: Pick<RunSnapshot, "seed" | "state" | "environment">,
+): RandomSource => {
+  const random = createSeededRandom(snapshot.seed);
+  const currentDay = Number(snapshot.state.day);
+
+  for (let day = 1; day <= currentDay; day += 1) {
+    const generated = generateEnvironment(dayNumber(day), random);
+    const historical = snapshot.state.ledger[day - 1]?.environment;
+    const expected = day === currentDay ? snapshot.environment : historical;
+    if (expected === undefined || !environmentsEqual(generated, expected)) {
+      return invalidSave(
+        `save.run.environmentSequence[${String(day)}]`,
+        "environment does not match the stored seed and simulation schema",
+      );
+    }
+  }
+
+  return random;
 };
 
 export const decodeRunSaveDocument = (value: unknown): RunSnapshot => {
@@ -451,12 +560,19 @@ export const decodeRunSaveDocument = (value: unknown): RunSnapshot => {
   }
 
   const run = asRecord(migrated["run"], "save.run");
-  return Object.freeze({
+  const state = parseGameState(run["state"], "save.run.state");
+  const environment = parseEnvironment(run["environment"], "save.run.environment");
+  const draft = parseDecision(run["draft"], "save.run.draft");
+  const snapshot = Object.freeze({
     seed: seed(asNonNegativeInteger(run["seed"], "save.run.seed")),
-    state: parseGameState(run["state"], "save.run.state"),
-    environment: parseEnvironment(run["environment"], "save.run.environment"),
-    draft: parseDecision(run["draft"], "save.run.draft"),
-  });
+    state,
+    environment,
+    draft,
+    phase: parsePhase(run["phase"], state, environment, draft, "save.run.phase"),
+  }) satisfies RunSnapshot;
+
+  restoreEnvironmentRandom(snapshot);
+  return snapshot;
 };
 
 export const exportRunSnapshot = (snapshot: RunSnapshot): string =>
@@ -564,7 +680,9 @@ export const loadCurrentRun = async (): Promise<RunSnapshot | null> => {
     );
     await transactionComplete(transaction);
     if (stored === undefined) return null;
-    if (typeof stored !== "string") return invalidSave("browser storage", "expected a text run document");
+    if (typeof stored !== "string") {
+      return invalidSave("browser storage", "expected a text run document");
+    }
     return importRunSnapshot(stored);
   } catch (error) {
     if (error instanceof RunPersistenceError) throw error;

--- a/apps/web/test/persistence.test.ts
+++ b/apps/web/test/persistence.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   SIMULATION_SCHEMA_VERSION,
   createInitialState,
+  createSeededRandom,
+  dayNumber,
+  generateEnvironment,
   glassCount,
   moneyCents,
-  neutralEnvironment,
   seed,
   signCount,
   simulateDay,
@@ -18,61 +20,151 @@ import {
   decodeRunSaveDocument,
   exportRunSnapshot,
   importRunSnapshot,
+  restoreEnvironmentRandom,
   type RunSnapshot,
 } from "../src/persistence.js";
 
-const createFixture = (): RunSnapshot => {
-  const decision = Object.freeze({
-    glasses: glassCount(20),
-    signs: signCount(1),
-    price: moneyCents(10),
-  });
-  const resolution = simulateDay(createInitialState(), decision, neutralEnvironment());
+const RUN_SEED = seed(0x1e_ad_2026);
+const decision = Object.freeze({
+  glasses: glassCount(20),
+  signs: signCount(1),
+  price: moneyCents(10),
+});
+
+const createDecidingFixture = (): RunSnapshot => {
+  const random = createSeededRandom(RUN_SEED);
+  const initialState = createInitialState();
+  const dayOneEnvironment = generateEnvironment(initialState.day, random);
+  const resolution = simulateDay(initialState, decision, dayOneEnvironment);
+  const dayTwoEnvironment = generateEnvironment(resolution.nextState.day, random);
 
   return Object.freeze({
-    seed: seed(0x1e_ad_2026),
+    seed: RUN_SEED,
     state: resolution.nextState,
-    environment: neutralEnvironment(),
+    environment: dayTwoEnvironment,
     draft: decision,
+    phase: Object.freeze({ kind: "deciding" }),
+  });
+};
+
+const createReportFixture = (): RunSnapshot => {
+  const random = createSeededRandom(RUN_SEED);
+  const state = createInitialState();
+  const environment = generateEnvironment(state.day, random);
+  const resolution = simulateDay(state, decision, environment);
+
+  return Object.freeze({
+    seed: RUN_SEED,
+    state,
+    environment,
+    draft: decision,
+    phase: Object.freeze({ kind: "report", resolution }),
   });
 };
 
 describe("run persistence", () => {
-  it("round-trips a complete deterministic run snapshot", () => {
-    const snapshot = createFixture();
+  it("round-trips a deciding snapshot with immutable history", () => {
+    const snapshot = createDecidingFixture();
     const restored = importRunSnapshot(exportRunSnapshot(snapshot));
 
     expect(restored).toEqual(snapshot);
     expect(restored.state.ledger).toHaveLength(1);
     expect(restored.state.ledger[0]).toEqual(snapshot.state.ledger[0]);
+    expect(restored.phase.kind).toBe("deciding");
+  });
+
+  it("round-trips the report phase without advancing or rewinding the day", () => {
+    const snapshot = createReportFixture();
+    const restored = importRunSnapshot(exportRunSnapshot(snapshot));
+
+    expect(restored).toEqual(snapshot);
+    expect(restored.state.day).toBe(snapshot.state.day);
+    expect(restored.phase.kind).toBe("report");
   });
 
   it("writes explicit save and simulation schema versions", () => {
-    const document = createRunSaveDocument(createFixture());
+    const document = createRunSaveDocument(createDecidingFixture());
 
     expect(document.saveSchemaVersion).toBe(RUN_SAVE_SCHEMA_VERSION);
     expect(document.simulationSchemaVersion).toBe(SIMULATION_SCHEMA_VERSION);
   });
 
-  it("migrates the pre-versioned prototype shape to schema version 1", () => {
-    const snapshot = createFixture();
+  it("migrates the pre-versioned prototype shape through schema version 2", () => {
+    const random = createSeededRandom(RUN_SEED);
+    const state = createInitialState();
+    const environment = generateEnvironment(state.day, random);
     const legacy = {
       schemaVersion: 0,
       simulationSchemaVersion: SIMULATION_SCHEMA_VERSION,
-      seed: Number(snapshot.seed),
-      state: snapshot.state,
-      environment: snapshot.environment,
+      seed: Number(RUN_SEED),
+      state,
+      environment,
     };
 
     const restored = decodeRunSaveDocument(legacy);
 
-    expect(restored.state).toEqual(snapshot.state);
-    expect(restored.environment).toEqual(snapshot.environment);
+    expect(restored.state).toEqual(state);
+    expect(restored.environment).toEqual(environment);
     expect(restored.draft).toEqual({ glasses: 20, signs: 1, price: 10 });
+    expect(restored.phase.kind).toBe("deciding");
+  });
+
+  it("migrates schema version 1 saves to a deciding phase", () => {
+    const current = createRunSaveDocument(createDecidingFixture());
+    const versionOne = {
+      saveSchemaVersion: 1,
+      simulationSchemaVersion: current.simulationSchemaVersion,
+      run: {
+        seed: current.run.seed,
+        state: current.run.state,
+        environment: current.run.environment,
+        draft: current.run.draft,
+      },
+    };
+
+    const restored = decodeRunSaveDocument(versionOne);
+
+    expect(restored.phase.kind).toBe("deciding");
+    expect(restored.state).toEqual(createDecidingFixture().state);
+  });
+
+  it("restores the RNG after the current environment draw", () => {
+    const snapshot = createDecidingFixture();
+    const restoredRandom = restoreEnvironmentRandom(snapshot);
+    const nextFromRestored = generateEnvironment(
+      dayNumber(Number(snapshot.state.day) + 1),
+      restoredRandom,
+    );
+
+    const replay = createSeededRandom(RUN_SEED);
+    generateEnvironment(dayNumber(1), replay);
+    generateEnvironment(dayNumber(2), replay);
+    const expected = generateEnvironment(dayNumber(3), replay);
+
+    expect(nextFromRestored).toEqual(expected);
+  });
+
+  it("rejects a current environment that does not belong to the stored seed", () => {
+    const document = createRunSaveDocument(createDecidingFixture());
+    const corrupt = {
+      ...document,
+      run: {
+        ...document.run,
+        environment: {
+          ...document.run.environment,
+          weather: {
+            kind: "thunderstorm",
+            demandMultiplier: 0,
+          },
+        },
+      },
+    };
+
+    expect(() => decodeRunSaveDocument(corrupt)).toThrow(/stored seed/);
   });
 
   it("rejects future save schemas with an actionable error", () => {
-    const document = createRunSaveDocument(createFixture());
+    const document = createRunSaveDocument(createDecidingFixture());
 
     expect(() =>
       decodeRunSaveDocument({
@@ -94,7 +186,7 @@ describe("run persistence", () => {
   });
 
   it("rejects saves from an incompatible simulation schema", () => {
-    const document = createRunSaveDocument(createFixture());
+    const document = createRunSaveDocument(createDecidingFixture());
 
     expect(() =>
       decodeRunSaveDocument({
@@ -105,7 +197,7 @@ describe("run persistence", () => {
   });
 
   it("rejects corrupt ledger history instead of recomputing it", () => {
-    const document = createRunSaveDocument(createFixture());
+    const document = createRunSaveDocument(createDecidingFixture());
     const corrupt = {
       ...document,
       run: {
@@ -118,6 +210,27 @@ describe("run persistence", () => {
     };
 
     expect(() => decodeRunSaveDocument(corrupt)).toThrow(/ending cash/);
+  });
+
+  it("rejects a tampered report resolution", () => {
+    const document = createRunSaveDocument(createReportFixture());
+    if (document.run.phase.kind !== "report") throw new Error("expected report fixture");
+
+    const corrupt = {
+      ...document,
+      run: {
+        ...document.run,
+        phase: {
+          kind: "report",
+          nextState: {
+            ...document.run.phase.nextState,
+            cash: document.run.phase.nextState.cash + 1,
+          },
+        },
+      },
+    };
+
+    expect(() => decodeRunSaveDocument(corrupt)).toThrow();
   });
 
   it("rejects invalid JSON before it reaches domain parsing", () => {

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,6 +1,6 @@
 # Run persistence contract
 
-Phase 8 introduces durable runs without making persistence part of the simulation engine.
+Phase 8 provides durable runs without making persistence part of the simulation engine.
 
 ## Boundary
 
@@ -23,29 +23,32 @@ The persistence boundary has four responsibilities:
 3. validate all imported/stored data before reconstructing branded domain values;
 4. adapt the validated document to native browser storage.
 
-It must never recompute historical ledger entries from current balance rules.
+It never recomputes historical ledger entries from current balance rules.
 
-## Schema version 1
+## Schema version 2
 
 A portable document records:
 
 - `saveSchemaVersion` — format/migration version;
 - `simulationSchemaVersion` — ruleset/domain compatibility version;
 - `run.seed` — deterministic environment-sequence identity;
-- `run.state` — current immutable game state including the full daily ledger;
+- `run.state` — state at the start of the current day, including immutable completed-day history;
 - `run.environment` — the already-selected current-day weather, sentiment, and event;
-- `run.draft` — the three current player decisions.
+- `run.draft` — the three current player decisions;
+- `run.phase` — either `deciding` or `report`; a report contains the validated next state produced by the current-day resolution.
 
-Money remains integer cents. Counts, days, seeds, multipliers, tiers, variant discriminants, and every ledger line are validated before conversion back into simulation types.
+Money remains integer cents. Counts, days, seeds, multipliers, tiers, variant discriminants, every ledger line, and phase payloads are validated before conversion back into simulation types.
 
-The current validator additionally checks that:
+The validator checks that:
 
 - ledger length equals the number of completed days;
 - ledger day numbers are contiguous from day 1;
-- current cash equals the final ledger entry's ending cash;
-- current debt equals the final ledger entry's ending loan balance.
+- current cash equals the final historical ledger entry's ending cash;
+- current debt equals the final historical ledger entry's ending loan balance;
+- every completed-day environment and the current environment belong to the stored seed under the matching simulation schema;
+- a stored report transition exactly matches the deterministic resolution of the stored state, draft, and environment.
 
-These checks reject corrupted or internally inconsistent documents rather than attempting repair by replaying under current rules.
+The final report check only verifies the current transition. Historical ledger entries are accepted as stored after structural/accounting consistency checks and are never regenerated from current balance constants.
 
 ## Save schema migration versus simulation compatibility
 
@@ -53,27 +56,56 @@ Save-schema migration and simulation/ruleset compatibility are intentionally sep
 
 A known older save schema may be migrated structurally into the current format. A save created against a different simulation schema is rejected unless a separate, explicit compatibility policy is implemented. This prevents a new balance model from silently changing historical outcomes.
 
-The initial migration fixture accepts the pre-versioned prototype shape (`schemaVersion: 0`) and wraps it in schema version 1 while supplying the original default three-control draft.
+Migration paths currently include:
+
+- prototype `schemaVersion: 0` -> schema 1 -> schema 2;
+- schema 1 -> schema 2, with the missing phase represented as `deciding`.
+
+A structural migration never pretends that an incompatible ruleset is compatible.
+
+## Deterministic environment restoration
+
+The environment RNG is reconstructed from `run.seed` by replaying environment selection through the current day. Each replayed completed-day environment is checked against its immutable ledger entry and the final draw is checked against `run.environment`.
+
+After validation, the resulting random source is positioned immediately after the current day's environment draw. Advancing from a restored report therefore generates exactly the same next-day environment as uninterrupted play.
+
+The random stream used by scene/audio presentation remains independent of this simulation contract.
 
 ## Browser storage
 
-The browser adapter uses IndexedDB rather than `localStorage` because a run contains structured historical data and needs an explicit storage version. One key, `current`, owns the active run in the first implementation.
+The browser adapter uses IndexedDB rather than `localStorage` because a run contains structured historical data and needs an explicit storage version. One key, `current`, owns the active run.
 
 Storage contains the same JSON text used for portable export. Loading therefore always traverses the same migration and validation path as importing a file; browser storage is not trusted merely because the application wrote it previously.
 
-## Portable import/export
+The application restores the current run before constructing `LemonadeApp`. Writes are serialized and occur at deterministic application transitions:
 
-`exportRunSnapshot()` emits human-inspectable JSON with a trailing newline. `importRunSnapshot()` parses, migrates, validates, and reconstructs the run. This format is independent of a UI framework and is suitable for a later native file adapter without changing simulation APIs.
+```text
+deciding -> report
+report   -> deciding
+```
 
-## Next integration slice
+Changing a slider is not itself a durable simulation transition. The current three-value draft is captured with the next committed transition.
 
-The web controller should next:
+If IndexedDB is unavailable, the game remains playable in a clearly reported non-persistent mode. If stored data is corrupt, unsupported, or from a future schema, bootstrap stops at an explicit recovery surface and leaves the document untouched until the player chooses to discard it.
 
-- restore the current run before constructing the primary day UI;
-- save at deterministic state-transition boundaries;
-- reconstruct the environment RNG position from the stored seed/day under the matching simulation schema;
-- expose explicit export/import/reset actions without adding daily operating controls;
-- surface storage/import failures as accessible actionable messages;
-- add Playwright coverage proving a run survives reload and portable import into a clean browser context.
+## Portable import/export and reset
+
+Run-data controls are deliberately outside the daily operating form so the game's decision surface remains exactly three variables and one Sell action.
+
+- **Export run** emits human-inspectable schema-v2 JSON.
+- **Import run** validates and stores the selected document, then reloads through the normal bootstrap path.
+- **Reset run** requires explicit confirmation before clearing the current IndexedDB run.
+
+Import and browser restore therefore share the same migration, validation, RNG-restoration, and application-construction path.
+
+## Certification
+
+Unit fixtures cover deciding/report round trips, legacy migration, future/incompatible versions, ledger corruption, report tampering, environment-seed mismatch, invalid JSON, and RNG positioning.
+
+Playwright covers:
+
+- report restoration across a browser reload;
+- next-day restoration after advancing from a report;
+- portable export followed by import into a separate clean browser context.
 
 A future `packages/persistence` extraction is appropriate if another runtime (for example Tauri) needs the same schema/migration layer. Until then, keeping the boundary in the only consuming runtime avoids creating a workspace package solely for indirection.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,11 +66,9 @@ Before submit it presents weather, sentiment, assets, costs, projected spend, an
 
 ## Phase 4 — ledger and charts (#6)
 
-Status: ledger/history visualization implemented; durable persistence remains a future enhancement.
+Status: ledger/history visualization and durable browser persistence implemented.
 
-The current UI uses native DOM + SVG rather than a charting framework. Historical values are exposed in a semantic table so the chart is never the only representation.
-
-Future persistence work should add a versioned storage adapter without changing the simulation API.
+The current UI uses native DOM + SVG rather than a charting framework. Historical values are exposed in a semantic table so the chart is never the only representation. Completed ledger history is persisted immutably and restored without recomputing old days under current balance constants.
 
 ## Phase 5 — vector 3D Lemonsville (#4)
 
@@ -101,20 +99,24 @@ Current finance progression includes named ledger treatment for supplier fees, t
 
 Further balance work should be driven by deterministic simulation fixtures rather than additional mandatory controls.
 
-## Phase 8 — persistence and run portability
+## Phase 8 — persistence and run portability (#21)
 
-Next architectural priority after the consolidated revival is stable run persistence.
+Status: implemented in the browser baseline.
 
-Required properties:
+Delivered:
 
-- explicit save schema version;
-- simulation/ruleset version;
-- validated load boundary;
-- immutable historical ledger preservation;
-- seed/environment identity sufficient for diagnostics and replay;
-- import/export format that does not depend on a UI framework.
+- explicit portable save schema with independent save and simulation/ruleset versions;
+- strict migration and validation boundary for all stored/imported data;
+- immutable completed-day ledger preservation;
+- deterministic seed/environment verification and RNG restoration;
+- explicit `deciding` and `report` phase persistence so reloads do not alter the current day;
+- native IndexedDB storage behind the web application boundary;
+- portable JSON export/import and explicit reset controls outside the daily decision form;
+- safe recovery for corrupt, unsupported, or future-version saves;
+- playable degraded mode when durable browser storage is unavailable;
+- unit fixtures plus Playwright coverage for reload persistence and clean-profile portability.
 
-Start with a browser adapter. Add native file integration only if the desktop shell is justified.
+The simulation package remains storage-agnostic. Native file integration should be added only if a future desktop shell earns that capability surface.
 
 ## Phase 9 — optional Tauri/native capabilities
 

--- a/e2e/daily-loop.spec.ts
+++ b/e2e/daily-loop.spec.ts
@@ -42,7 +42,7 @@ test("restores both report and next-day phases across reloads", async ({ page })
   const reportHeading = page.getByRole("heading", { name: /sold$/ });
   const reportText = await reportHeading.textContent();
   if (reportText === null) throw new Error("expected a day report heading");
-  await expect(page.getByRole("status")).toContainText("Day report saved locally");
+  await expect(page.locator("#run-status")).toContainText("Day report saved locally");
 
   await page.reload();
   await expect(page.getByRole("heading", { name: reportText })).toBeVisible();
@@ -50,7 +50,7 @@ test("restores both report and next-day phases across reloads", async ({ page })
 
   await page.getByRole("button", { name: "Plan next day" }).click();
   await expect(page.locator("#status-day")).toHaveText("2");
-  await expect(page.getByRole("status")).toContainText("Next day saved locally");
+  await expect(page.locator("#run-status")).toContainText("Next day saved locally");
 
   await page.reload();
   await expect(page.locator("#status-day")).toHaveText("2");
@@ -71,7 +71,6 @@ test("exports and imports a progressed run into a clean browser profile", async 
   await sourcePage.getByRole("button", { name: "Export run" }).click();
   const download = await downloadPromise;
   const downloadPath = await download.path();
-  if (downloadPath === null) throw new Error("expected exported run download path");
   const runDocument = await readFile(downloadPath);
 
   const target = await browser.newContext({ baseURL });

--- a/e2e/daily-loop.spec.ts
+++ b/e2e/daily-loop.spec.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { expect, test } from "@playwright/test";
 
 test("plays a complete day with keyboard controls", async ({ page }) => {
@@ -31,4 +33,67 @@ test("prevents an unaffordable plan before submission", async ({ page }) => {
 
   await expect(page.getByRole("alert")).toContainText("available cash and credit");
   await expect(page.getByRole("button", { name: "Sell for the day" })).toBeDisabled();
+});
+
+test("restores both report and next-day phases across reloads", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Sell for the day" }).click();
+
+  const reportHeading = page.getByRole("heading", { name: /sold$/ });
+  const reportText = await reportHeading.textContent();
+  if (reportText === null) throw new Error("expected a day report heading");
+  await expect(page.getByRole("status")).toContainText("Day report saved locally");
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: reportText })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Plan next day" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Plan next day" }).click();
+  await expect(page.locator("#status-day")).toHaveText("2");
+  await expect(page.getByRole("status")).toContainText("Next day saved locally");
+
+  await page.reload();
+  await expect(page.locator("#status-day")).toHaveText("2");
+  await expect(page.getByRole("button", { name: "Sell for the day" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sales history" })).toBeVisible();
+});
+
+test("exports and imports a progressed run into a clean browser profile", async ({ browser }) => {
+  const baseURL = "http://127.0.0.1:4173";
+  const source = await browser.newContext({ baseURL, acceptDownloads: true });
+  const sourcePage = await source.newPage();
+  await sourcePage.goto("/");
+  await sourcePage.getByRole("button", { name: "Sell for the day" }).click();
+  await sourcePage.getByRole("button", { name: "Plan next day" }).click();
+  await expect(sourcePage.locator("#status-day")).toHaveText("2");
+
+  const downloadPromise = sourcePage.waitForEvent("download");
+  await sourcePage.getByRole("button", { name: "Export run" }).click();
+  const download = await downloadPromise;
+  const downloadPath = await download.path();
+  if (downloadPath === null) throw new Error("expected exported run download path");
+  const runDocument = await readFile(downloadPath);
+
+  const target = await browser.newContext({ baseURL });
+  const targetPage = await target.newPage();
+  await targetPage.goto("/");
+  await expect(targetPage.locator("#status-day")).toHaveText("1");
+
+  const chooserPromise = targetPage.waitForEvent("filechooser");
+  await targetPage.getByRole("button", { name: "Import run" }).click();
+  const chooser = await chooserPromise;
+  const reloadPromise = targetPage.waitForEvent("load");
+  await chooser.setFiles({
+    name: "lemonade-run.json",
+    mimeType: "application/json",
+    buffer: runDocument,
+  });
+  await reloadPromise;
+
+  await expect(targetPage.locator("#status-day")).toHaveText("2");
+  await expect(targetPage.getByRole("heading", { name: "Sales history" })).toBeVisible();
+  await expect(targetPage.getByRole("button", { name: "Sell for the day" })).toBeVisible();
+
+  await target.close();
+  await source.close();
 });


### PR DESCRIPTION
## Scope
Completes the browser integration for Phase 8 / #21 on top of the merged persistence foundation.

- evolves portable saves to schema v2 with explicit `deciding` / `report` phase persistence
- preserves a visible day report across reload instead of rewinding or advancing implicitly
- migrates schema v0 and v1 saves forward while keeping simulation-schema compatibility separate
- validates the stored environment sequence against the run seed and reconstructs the RNG position after the current-day draw
- restores the current run before constructing `LemonadeApp`
- serializes IndexedDB writes at deterministic state-transition boundaries
- adds explicit Export / Import / Reset run controls outside the three-control daily form
- leaves corrupt/unsupported saves untouched behind an actionable recovery surface
- degrades to playable non-persistent mode when IndexedDB is unavailable
- adds unit coverage for phase round-trips, migration, deterministic RNG restoration, tamper/corruption rejection
- adds Playwright coverage for report reload, next-day reload, and export/import into a separate clean browser context
- documents the schema-v2 contract and browser lifecycle

If CI remains green, this satisfies the browser persistence and portability acceptance criteria in #21.

Refs #21