### PR TITLE
feat: add deterministic balance certification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           install: false
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
+      - run: pnpm certify
 
   browser:
     runs-on: ubuntu-latest

--- a/docs/balance-certification.md
+++ b/docs/balance-certification.md
@@ -1,0 +1,93 @@
+# Balance and gameplay certification
+
+Balance changes are evaluated with deterministic evidence rather than intuition alone.
+
+The certification harness lives in `packages/simulation` and calls only the pure simulation API. It does not depend on DOM state, browser timing, audio, storage, rendering, or network data.
+
+Run the human-reviewable report with:
+
+```sh
+pnpm certify
+```
+
+The command builds the simulation package, executes the fixed certification corpus, fails on violated guardrails, and prints a deterministic Markdown report.
+
+## Fixture corpus
+
+The baseline corpus runs seven strategy profiles across sixteen fixed seeds for up to 90 simulated days:
+
+- `conservative` — low price, no advertising, modest inventory;
+- `aggressive-inventory` — commits most available working capital to stock;
+- `advertising-heavy` — sustains five signs and inventory for the induced demand;
+- `high-price` — tests high-margin, low-volume play;
+- `poor-decisions` — deliberately combines excessive signs with a demand-suppressing price;
+- `adaptive` — changes all three decisions from visible weather and sentiment;
+- `progression` — a growth policy intended to exercise every finance tier.
+
+Strategies are affordability-clamped through the same simulation finance constraints. A run is considered bankrupt when even the day's predictable fixed obligations cannot be funded from available cash and credit.
+
+The corpus is intentionally not an optimizer. It represents distinct, understandable player behaviors so changes in relative outcomes remain visible.
+
+## Hard invariants
+
+These are correctness properties. CI must fail immediately if any simulated day violates them:
+
+- sold glasses never exceed prepared glasses;
+- revenue equals sold quantity multiplied by price;
+- named operating ledger lines reconcile to reported expenses;
+- revenue plus finance income minus expenses equals net result;
+- cash delta reconciles to opening and ending cash;
+- loan-interest settlement stays within accrued-interest bounds;
+- cash flow reconciles after borrowing, operating cash expenses, interest, and repayment;
+- next-state cash and debt match the ledger entry;
+- day numbers advance exactly once;
+- the ledger appends exactly one immutable entry per resolved day.
+
+These invariants are not balance targets and should not be weakened to make a tuning change pass.
+
+## Design guardrails
+
+Guardrails are intentionally broad. They detect clearly implausible regressions while leaving room for deliberate tuning:
+
+- conservative, advertising-heavy, adaptive, and progression profiles survive the fixed 90-day corpus;
+- conservative and adaptive play retain positive growth floors;
+- the progression profile reaches every current finance tier and has sufficient equity to exercise late finance mechanics;
+- intentionally poor play does not outperform adaptive play at the median;
+- high-price play retains a material sell-through penalty;
+- advertising-heavy and conservative fixtures continue to exercise meaningfully different advertising regimes;
+- median strategy outcomes retain a substantial equity spread;
+- sell-through outcomes retain a substantial spread;
+- controlled price probes remain demand-decreasing;
+- controlled advertising probes retain positive but non-increasing marginal demand benefit;
+- controlled weather and sentiment probes retain their intended demand ordering.
+
+Changing a guardrail is a design decision. The PR should explain why the old range is no longer desirable and what player behavior the new range is intended to permit.
+
+## Human-review metrics
+
+The report deliberately includes metrics that should be reviewed rather than automatically optimized:
+
+- survival and bankruptcy timing;
+- final equity distribution (`min`, `p50`, `p90`, `max`);
+- sell-through and waste;
+- average price and advertising level;
+- isolated weather and sentiment demand contribution;
+- exceptional-event frequency and realized impact;
+- maximum tier and earliest tier-entry days;
+- aggregate taxes, supplier fees, bank fees, debt interest, borrowing, repayment, and savings interest;
+- controlled price, advertising, weather, and sentiment demand probes.
+
+A metric moving is not automatically a defect. The purpose is to make large distribution shifts visible and reviewable.
+
+## Ruleset changes and replay compatibility
+
+The certification report records the simulation schema version. Any change to balance constants or random-draw ordering that alters deterministic outcomes must be reviewed together with persistence/replay compatibility.
+
+Do not update expected behavior merely because a fixture changed. First determine whether the change is:
+
+1. a correctness regression;
+2. an intentional balance change within existing guardrails;
+3. an intentional design change that requires guardrail revision; or
+4. a simulation-schema change requiring replay/persistence treatment.
+
+The fixed seed corpus should remain stable unless there is a documented reason to change the sampling contract.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,7 +118,25 @@ Delivered:
 
 The simulation package remains storage-agnostic. Native file integration should be added only if a future desktop shell earns that capability surface.
 
-## Phase 9 — optional Tauri/native capabilities
+## Phase 9 — balance and gameplay certification (#22)
+
+Status: implemented as a deterministic simulation certification loop.
+
+The certification baseline provides:
+
+- seven understandable strategy profiles spanning conservative, aggressive, advertising-heavy, high-price, intentionally poor, adaptive, and progression play;
+- sixteen fixed seeds and a 90-day certification horizon;
+- per-day accounting, cash-flow, inventory, debt, day-continuity, and immutable-ledger invariants;
+- survival/bankruptcy, equity distribution, sell-through/waste, pricing, advertising, environment, event, progression, and finance-burden metrics;
+- controlled price, advertising, weather, and sentiment probes;
+- broad gameplay guardrails that detect implausible regressions without defining a single optimal strategy;
+- explicit verification that the progression fixture reaches every current finance tier;
+- deterministic Markdown reporting through `pnpm certify`;
+- CI execution of the certification command in addition to unit and browser acceptance coverage.
+
+Balance changes should now be reviewed against this evidence. Guardrails are product decisions, not snapshots to update mechanically: a deliberate guardrail change must explain the intended player behavior and any simulation-schema/replay implications.
+
+## Phase 10 — optional Tauri/native capabilities
 
 Begin only when a native capability has a measured product benefit.
 
@@ -132,11 +150,11 @@ Potential use cases:
 
 Do not port simulation code to Rust merely to justify Tauri. If shared logic ever exists in more than one language, require conformance fixtures across implementations.
 
-## Balance and certification loop
+## Ongoing balance and certification loop
 
 For each ruleset version:
 
-- run seeded strategy fixtures;
+- run the fixed certification corpus and inspect the deterministic report;
 - inspect bankruptcy and runaway-growth rates;
 - verify weather/sentiment uncertainty matters without dominating player decisions;
 - verify advertising has diminishing returns;
@@ -145,4 +163,4 @@ For each ruleset version:
 - verify accounting identities and rounding boundaries;
 - run the complete keyboard/browser acceptance flow.
 
-Changes to balance constants require tests/fixture updates and an explicit note that replay outcomes may differ under the new ruleset.
+Changes to balance constants require explicit review of fixture/report movement and an explicit note when replay outcomes may differ under the new ruleset.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint .",
     "test": "pnpm -r --if-present test",
     "test:e2e": "playwright test",
+    "certify": "pnpm --filter @lemonade/simulation build && node scripts/certify.mjs",
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {

--- a/packages/simulation/src/certification.ts
+++ b/packages/simulation/src/certification.ts
@@ -1,0 +1,861 @@
+import { availableOperatingFunds, financeRulesForTier, predictableFixedObligations } from "./finance.js";
+import type {
+  DailyLedgerEntry,
+  DayDecision,
+  DayEnvironment,
+  DayResolution,
+  GameState,
+  LedgerLineKind,
+  ProgressionTier,
+} from "./model.js";
+import {
+  basisPoints,
+  glassCount,
+  moneyCents,
+  seed,
+  signCount,
+  type Seed,
+} from "./primitives.js";
+import { createSeededRandom } from "./rng.js";
+import { generateEnvironment, neutralEnvironment } from "./environment.js";
+import { potentialDemand } from "./rules.js";
+import { simulateDay } from "./simulate.js";
+import { createInitialState } from "./state.js";
+import { SIMULATION_SCHEMA_VERSION } from "./index.js";
+
+export const CERTIFICATION_HORIZON_DAYS = 90 as const;
+
+export const CERTIFICATION_SEEDS = Object.freeze([
+  0x1e_ad_2026,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+] as const);
+
+export const CERTIFICATION_STRATEGY_NAMES = Object.freeze([
+  "conservative",
+  "aggressive-inventory",
+  "advertising-heavy",
+  "high-price",
+  "poor-decisions",
+  "adaptive",
+  "progression",
+] as const);
+
+export type CertificationStrategyName = (typeof CERTIFICATION_STRATEGY_NAMES)[number];
+
+type ProposedDecision = Readonly<{
+  glasses: number;
+  signs: number;
+  price: number;
+}>;
+
+type StrategyDefinition = Readonly<{
+  name: CertificationStrategyName;
+  description: string;
+  decide(state: GameState, environment: DayEnvironment): DayDecision;
+}>;
+
+export type FinanceBurden = Readonly<{
+  taxesCents: number;
+  supplierFeesCents: number;
+  bankFeesCents: number;
+  loanInterestCents: number;
+  savingsInterestCents: number;
+  borrowedCents: number;
+  repaidCents: number;
+}>;
+
+export type CertificationRunSummary = Readonly<{
+  strategy: CertificationStrategyName;
+  seed: number;
+  completedDays: number;
+  bankruptcyDay: number | null;
+  finalCashCents: number;
+  finalLoanBalanceCents: number;
+  finalEquityCents: number;
+  prepared: number;
+  sold: number;
+  waste: number;
+  sellThroughBps: number;
+  averagePriceHundredthsOfCent: number;
+  averageSignsHundredths: number;
+  exceptionalEvents: number;
+  weatherContributionHundredths: number;
+  sentimentContributionHundredths: number;
+  eventImpactHundredths: number;
+  maxTier: ProgressionTier;
+  firstDayByTier: readonly (number | null)[];
+  finance: FinanceBurden;
+}>;
+
+export type ProfileCertificationSummary = Readonly<{
+  strategy: CertificationStrategyName;
+  description: string;
+  runs: number;
+  bankruptRuns: number;
+  earliestBankruptcyDay: number | null;
+  survivalRateBps: number;
+  finalEquityCents: Readonly<{
+    min: number;
+    p50: number;
+    p90: number;
+    max: number;
+  }>;
+  sellThroughBps: number;
+  wasteRateBps: number;
+  averagePriceHundredthsOfCent: number;
+  averageSignsHundredths: number;
+  exceptionalEventRateBps: number;
+  weatherContributionHundredths: number;
+  sentimentContributionHundredths: number;
+  eventImpactHundredths: number;
+  maxTier: ProgressionTier;
+  earliestDayByTier: readonly (number | null)[];
+  finance: FinanceBurden;
+}>;
+
+export type ControlledProbes = Readonly<{
+  priceDemand: readonly Readonly<{ priceCents: number; demand: number }>[];
+  advertising: readonly Readonly<{ signs: number; demand: number; marginalDemand: number }>[];
+  weather: readonly Readonly<{ kind: string; demand: number }>[];
+  sentiment: readonly Readonly<{ kind: string; demand: number }>[];
+}>;
+
+export type BalanceCertificationReport = Readonly<{
+  simulationSchemaVersion: number;
+  horizonDays: number;
+  seeds: readonly number[];
+  profiles: readonly ProfileCertificationSummary[];
+  probes: ControlledProbes;
+}>;
+
+const expenseLineKinds: readonly LedgerLineKind[] = Object.freeze([
+  "production",
+  "advertising",
+  "operating-fee",
+  "tax",
+  "bank-fee",
+  "loan-interest",
+]);
+
+const cashExpenseLineKinds: readonly LedgerLineKind[] = Object.freeze([
+  "production",
+  "advertising",
+  "operating-fee",
+  "tax",
+  "bank-fee",
+]);
+
+const financeZero = (): FinanceBurden =>
+  Object.freeze({
+    taxesCents: 0,
+    supplierFeesCents: 0,
+    bankFeesCents: 0,
+    loanInterestCents: 0,
+    savingsInterestCents: 0,
+    borrowedCents: 0,
+    repaidCents: 0,
+  });
+
+const failCertification = (message: string): never => {
+  throw new Error(`Balance certification failed: ${message}`);
+};
+
+const requireInvariant = (condition: boolean, message: string): void => {
+  if (!condition) failCertification(message);
+};
+
+const variableBudgetCents = (state: GameState): number =>
+  Math.max(
+    0,
+    Number(availableOperatingFunds(state)) - Number(predictableFixedObligations(state)),
+  );
+
+const affordableDecision = (state: GameState, proposed: ProposedDecision): DayDecision => {
+  const budget = variableBudgetCents(state);
+  const requestedSigns = Math.max(0, Math.floor(proposed.signs));
+  const requestedGlasses = Math.max(0, Math.floor(proposed.glasses));
+  const price = Math.max(1, Math.floor(proposed.price));
+  const signs = Math.min(requestedSigns, Math.floor(budget / Number(state.signCost)));
+  const remaining = budget - signs * Number(state.signCost);
+  const glasses = Math.min(requestedGlasses, Math.floor(remaining / Number(state.unitCost)));
+
+  return Object.freeze({
+    glasses: glassCount(glasses),
+    signs: signCount(signs),
+    price: moneyCents(price),
+  });
+};
+
+const environmentStrength = (environment: DayEnvironment): number =>
+  (Number(environment.weather.demandMultiplier) * Number(environment.sentiment.demandMultiplier)) /
+  100_000_000;
+
+const strategies: Readonly<Record<CertificationStrategyName, StrategyDefinition>> = Object.freeze({
+  conservative: Object.freeze({
+    name: "conservative",
+    description: "Low price, no advertising, modest inventory.",
+    decide: (state: GameState): DayDecision =>
+      affordableDecision(state, { glasses: 28, signs: 0, price: 8 }),
+  }),
+  "aggressive-inventory": Object.freeze({
+    name: "aggressive-inventory",
+    description: "Commits most available working capital to inventory.",
+    decide: (state: GameState): DayDecision => {
+      const targetGlasses = Math.floor((variableBudgetCents(state) * 0.85) / Number(state.unitCost));
+      return affordableDecision(state, {
+        glasses: Math.min(160, targetGlasses),
+        signs: 1,
+        price: 9,
+      });
+    },
+  }),
+  "advertising-heavy": Object.freeze({
+    name: "advertising-heavy",
+    description: "Keeps five signs active and carries inventory for the resulting demand.",
+    decide: (state: GameState): DayDecision =>
+      affordableDecision(state, { glasses: 55, signs: 5, price: 10 }),
+  }),
+  "high-price": Object.freeze({
+    name: "high-price",
+    description: "Tests high-margin, low-volume play at twice the reference price.",
+    decide: (state: GameState): DayDecision =>
+      affordableDecision(state, { glasses: 30, signs: 1, price: 20 }),
+  }),
+  "poor-decisions": Object.freeze({
+    name: "poor-decisions",
+    description: "Intentionally overspends on signs while charging a demand-suppressing price.",
+    decide: (state: GameState): DayDecision =>
+      affordableDecision(state, { glasses: 10, signs: 8, price: 30 }),
+  }),
+  adaptive: Object.freeze({
+    name: "adaptive",
+    description: "Adjusts inventory, signs, and price from the visible weather/sentiment signal.",
+    decide: (state: GameState, environment: DayEnvironment): DayDecision => {
+      const strength = environmentStrength(environment);
+      return affordableDecision(state, {
+        glasses: strength >= 1.5 ? 70 : strength >= 1 ? 50 : 35,
+        signs: strength < 0.9 ? 2 : 1,
+        price: strength >= 1.15 ? 8 : strength >= 0.9 ? 9 : 7,
+      });
+    },
+  }),
+  progression: Object.freeze({
+    name: "progression",
+    description: "A growth-oriented policy intended to exercise every finance tier.",
+    decide: (state: GameState, environment: DayEnvironment): DayDecision => {
+      const strength = environmentStrength(environment);
+      return affordableDecision(state, {
+        glasses: strength >= 1.5 ? 75 : strength >= 0.9 ? 55 : 35,
+        signs: 2,
+        price: 9,
+      });
+    },
+  }),
+});
+
+const sumLines = (entry: DailyLedgerEntry, kinds: readonly LedgerLineKind[]): number =>
+  entry.lines.reduce(
+    (total, line) => total + (kinds.includes(line.kind) ? Number(line.amount) : 0),
+    0,
+  );
+
+const lineAmount = (entry: DailyLedgerEntry, kind: LedgerLineKind): number =>
+  entry.lines.reduce(
+    (total, line) => total + (line.kind === kind ? Number(line.amount) : 0),
+    0,
+  );
+
+const certifyDailyResolution = (resolution: DayResolution): void => {
+  const { previousState, nextState, entry } = resolution;
+  const prepared = Number(entry.decision.glasses);
+  const sold = Number(entry.sold);
+  const expectedRevenue = sold * Number(entry.decision.price);
+  const expenseLines = sumLines(entry, expenseLineKinds);
+  const cashExpenseLines = sumLines(entry, cashExpenseLineKinds);
+  const loanInterest = lineAmount(entry, "loan-interest");
+  const paidLoanInterest =
+    Number(previousState.loanBalance) +
+    Number(entry.borrowed) +
+    loanInterest -
+    Number(entry.repaid) -
+    Number(entry.endingLoanBalance);
+  const expectedCash =
+    Number(previousState.cash) +
+    Number(entry.borrowed) +
+    Number(entry.revenue) +
+    Number(entry.financeIncome) -
+    cashExpenseLines -
+    paidLoanInterest -
+    Number(entry.repaid);
+
+  requireInvariant(sold <= prepared, `day ${String(Number(entry.day))} sold more than prepared`);
+  requireInvariant(expectedRevenue === Number(entry.revenue), `day ${String(Number(entry.day))} revenue identity`);
+  requireInvariant(expenseLines === Number(entry.expenses), `day ${String(Number(entry.day))} expense identity`);
+  requireInvariant(
+    Number(entry.revenue) + Number(entry.financeIncome) - Number(entry.expenses) === Number(entry.net),
+    `day ${String(Number(entry.day))} net identity`,
+  );
+  requireInvariant(
+    Number(entry.endingCash) - Number(previousState.cash) === Number(entry.cashDelta),
+    `day ${String(Number(entry.day))} cash-delta identity`,
+  );
+  requireInvariant(
+    paidLoanInterest >= 0 && paidLoanInterest <= loanInterest,
+    `day ${String(Number(entry.day))} loan-interest settlement bounds`,
+  );
+  requireInvariant(expectedCash === Number(entry.endingCash), `day ${String(Number(entry.day))} cash-flow identity`);
+  requireInvariant(nextState.cash === entry.endingCash, `day ${String(Number(entry.day))} next cash continuity`);
+  requireInvariant(
+    nextState.loanBalance === entry.endingLoanBalance,
+    `day ${String(Number(entry.day))} next debt continuity`,
+  );
+  requireInvariant(
+    Number(nextState.day) === Number(previousState.day) + 1,
+    `day ${String(Number(entry.day))} day continuity`,
+  );
+  requireInvariant(
+    nextState.ledger.length === previousState.ledger.length + 1,
+    `day ${String(Number(entry.day))} ledger append`,
+  );
+};
+
+const financeForEntry = (entry: DailyLedgerEntry): FinanceBurden =>
+  Object.freeze({
+    taxesCents: lineAmount(entry, "tax"),
+    supplierFeesCents: lineAmount(entry, "operating-fee"),
+    bankFeesCents: lineAmount(entry, "bank-fee"),
+    loanInterestCents: lineAmount(entry, "loan-interest"),
+    savingsInterestCents: lineAmount(entry, "savings-interest"),
+    borrowedCents: Number(entry.borrowed),
+    repaidCents: Number(entry.repaid),
+  });
+
+const addFinance = (left: FinanceBurden, right: FinanceBurden): FinanceBurden =>
+  Object.freeze({
+    taxesCents: left.taxesCents + right.taxesCents,
+    supplierFeesCents: left.supplierFeesCents + right.supplierFeesCents,
+    bankFeesCents: left.bankFeesCents + right.bankFeesCents,
+    loanInterestCents: left.loanInterestCents + right.loanInterestCents,
+    savingsInterestCents: left.savingsInterestCents + right.savingsInterestCents,
+    borrowedCents: left.borrowedCents + right.borrowedCents,
+    repaidCents: left.repaidCents + right.repaidCents,
+  });
+
+const roundRatio = (numerator: number, denominator: number, scale: number): number =>
+  denominator === 0 ? 0 : Math.round((numerator * scale) / denominator);
+
+const demandContribution = (
+  entry: DailyLedgerEntry,
+): Readonly<{ weather: number; sentiment: number; event: number }> => {
+  const neutral = neutralEnvironment();
+  const neutralDemand = Number(
+    potentialDemand(entry.decision.price, entry.decision.signs, neutral),
+  );
+  const weatherOnly: DayEnvironment = Object.freeze({
+    weather: entry.environment.weather,
+    sentiment: neutral.sentiment,
+    event: neutral.event,
+  });
+  const sentimentOnly: DayEnvironment = Object.freeze({
+    weather: neutral.weather,
+    sentiment: entry.environment.sentiment,
+    event: neutral.event,
+  });
+  const eventNeutralized: DayEnvironment = Object.freeze({
+    weather: entry.environment.weather,
+    sentiment: entry.environment.sentiment,
+    event: neutral.event,
+  });
+  const weatherDemand = Number(
+    potentialDemand(entry.decision.price, entry.decision.signs, weatherOnly),
+  );
+  const sentimentDemand = Number(
+    potentialDemand(entry.decision.price, entry.decision.signs, sentimentOnly),
+  );
+  const baselineEventDemand = Number(
+    potentialDemand(entry.decision.price, entry.decision.signs, eventNeutralized),
+  );
+  const baselineEventSold = Math.min(Number(entry.decision.glasses), baselineEventDemand);
+
+  return Object.freeze({
+    weather: Math.abs(weatherDemand - neutralDemand),
+    sentiment: Math.abs(sentimentDemand - neutralDemand),
+    event: Math.abs(Number(entry.sold) - baselineEventSold),
+  });
+};
+
+const runStrategy = (
+  strategy: StrategyDefinition,
+  runSeed: Seed,
+  horizonDays: number,
+): CertificationRunSummary => {
+  let state = createInitialState();
+  const random = createSeededRandom(runSeed);
+  let bankruptcyDay: number | null = null;
+  let prepared = 0;
+  let sold = 0;
+  let totalPrice = 0;
+  let totalSigns = 0;
+  let exceptionalEvents = 0;
+  let weatherContribution = 0;
+  let sentimentContribution = 0;
+  let eventImpact = 0;
+  let finance = financeZero();
+  let maxTier: ProgressionTier = state.tier;
+  const firstDayByTier: (number | null)[] = [1, null, null, null, null];
+
+  for (let index = 0; index < horizonDays; index += 1) {
+    if (Number(availableOperatingFunds(state)) < Number(predictableFixedObligations(state))) {
+      bankruptcyDay = Number(state.day);
+      break;
+    }
+
+    const environment = generateEnvironment(state.day, random);
+    const decision = strategy.decide(state, environment);
+    const resolution = simulateDay(state, decision, environment);
+    certifyDailyResolution(resolution);
+
+    const entry = resolution.entry;
+    const contribution = demandContribution(entry);
+    prepared += Number(entry.decision.glasses);
+    sold += Number(entry.sold);
+    totalPrice += Number(entry.decision.price);
+    totalSigns += Number(entry.decision.signs);
+    exceptionalEvents += entry.environment.event.kind === "none" ? 0 : 1;
+    weatherContribution += contribution.weather;
+    sentimentContribution += contribution.sentiment;
+    eventImpact += contribution.event;
+    finance = addFinance(finance, financeForEntry(entry));
+
+    state = resolution.nextState;
+    maxTier = state.tier > maxTier ? state.tier : maxTier;
+    if (firstDayByTier[state.tier] === null) {
+      firstDayByTier[state.tier] = Number(state.day);
+    }
+  }
+
+  const completedDays = state.ledger.length;
+  const waste = prepared - sold;
+
+  return Object.freeze({
+    strategy: strategy.name,
+    seed: Number(runSeed),
+    completedDays,
+    bankruptcyDay,
+    finalCashCents: Number(state.cash),
+    finalLoanBalanceCents: Number(state.loanBalance),
+    finalEquityCents: Number(state.cash) - Number(state.loanBalance),
+    prepared,
+    sold,
+    waste,
+    sellThroughBps: roundRatio(sold, prepared, 10_000),
+    averagePriceHundredthsOfCent: roundRatio(totalPrice, completedDays, 100),
+    averageSignsHundredths: roundRatio(totalSigns, completedDays, 100),
+    exceptionalEvents,
+    weatherContributionHundredths: roundRatio(weatherContribution, completedDays, 100),
+    sentimentContributionHundredths: roundRatio(sentimentContribution, completedDays, 100),
+    eventImpactHundredths: roundRatio(eventImpact, completedDays, 100),
+    maxTier,
+    firstDayByTier: Object.freeze(firstDayByTier),
+    finance,
+  });
+};
+
+const sorted = (values: readonly number[]): number[] => [...values].sort((a, b) => a - b);
+
+const percentile = (values: readonly number[], ratio: number): number => {
+  if (values.length === 0) return failCertification("cannot summarize an empty value set");
+  const ordered = sorted(values);
+  const index = Math.floor((ordered.length - 1) * ratio);
+  const value = ordered[index];
+  if (value === undefined) return failCertification("percentile index escaped value set");
+  return value;
+};
+
+const aggregateFinance = (runs: readonly CertificationRunSummary[]): FinanceBurden =>
+  runs.reduce<FinanceBurden>((total, run) => addFinance(total, run.finance), financeZero());
+
+const earliestTierDays = (runs: readonly CertificationRunSummary[]): readonly (number | null)[] =>
+  Object.freeze(
+    [0, 1, 2, 3, 4].map((tier) => {
+      const days = runs
+        .map((run) => run.firstDayByTier[tier] ?? null)
+        .filter((day): day is number => day !== null);
+      return days.length === 0 ? null : Math.min(...days);
+    }),
+  );
+
+const aggregateProfile = (
+  strategy: StrategyDefinition,
+  runs: readonly CertificationRunSummary[],
+): ProfileCertificationSummary => {
+  const completedDays = runs.reduce((total, run) => total + run.completedDays, 0);
+  const prepared = runs.reduce((total, run) => total + run.prepared, 0);
+  const sold = runs.reduce((total, run) => total + run.sold, 0);
+  const exceptionalEvents = runs.reduce((total, run) => total + run.exceptionalEvents, 0);
+  const bankruptDays = runs
+    .map((run) => run.bankruptcyDay)
+    .filter((day): day is number => day !== null);
+  const equities = runs.map((run) => run.finalEquityCents);
+  const maxTier = runs.reduce<ProgressionTier>(
+    (maximum, run) => (run.maxTier > maximum ? run.maxTier : maximum),
+    0,
+  );
+
+  return Object.freeze({
+    strategy: strategy.name,
+    description: strategy.description,
+    runs: runs.length,
+    bankruptRuns: bankruptDays.length,
+    earliestBankruptcyDay: bankruptDays.length === 0 ? null : Math.min(...bankruptDays),
+    survivalRateBps: roundRatio(runs.length - bankruptDays.length, runs.length, 10_000),
+    finalEquityCents: Object.freeze({
+      min: percentile(equities, 0),
+      p50: percentile(equities, 0.5),
+      p90: percentile(equities, 0.9),
+      max: percentile(equities, 1),
+    }),
+    sellThroughBps: roundRatio(sold, prepared, 10_000),
+    wasteRateBps: roundRatio(prepared - sold, prepared, 10_000),
+    averagePriceHundredthsOfCent: roundRatio(
+      runs.reduce((total, run) => total + run.averagePriceHundredthsOfCent * run.completedDays, 0),
+      completedDays,
+      1,
+    ),
+    averageSignsHundredths: roundRatio(
+      runs.reduce((total, run) => total + run.averageSignsHundredths * run.completedDays, 0),
+      completedDays,
+      1,
+    ),
+    exceptionalEventRateBps: roundRatio(exceptionalEvents, completedDays, 10_000),
+    weatherContributionHundredths: roundRatio(
+      runs.reduce((total, run) => total + run.weatherContributionHundredths * run.completedDays, 0),
+      completedDays,
+      1,
+    ),
+    sentimentContributionHundredths: roundRatio(
+      runs.reduce((total, run) => total + run.sentimentContributionHundredths * run.completedDays, 0),
+      completedDays,
+      1,
+    ),
+    eventImpactHundredths: roundRatio(
+      runs.reduce((total, run) => total + run.eventImpactHundredths * run.completedDays, 0),
+      completedDays,
+      1,
+    ),
+    maxTier,
+    earliestDayByTier: earliestTierDays(runs),
+    finance: aggregateFinance(runs),
+  });
+};
+
+const controlledProbes = (): ControlledProbes => {
+  const neutral = neutralEnvironment();
+  const priceDemand = Object.freeze(
+    [5, 8, 10, 12, 15, 20].map((priceCents) =>
+      Object.freeze({
+        priceCents,
+        demand: Number(potentialDemand(moneyCents(priceCents), signCount(0), neutral)),
+      }),
+    ),
+  );
+
+  let previousDemand = 0;
+  const advertising = Object.freeze(
+    [0, 1, 2, 3, 4, 5].map((signs) => {
+      const demand = Number(potentialDemand(moneyCents(10), signCount(signs), neutral));
+      const point = Object.freeze({
+        signs,
+        demand,
+        marginalDemand: signs === 0 ? demand : demand - previousDemand,
+      });
+      previousDemand = demand;
+      return point;
+    }),
+  );
+
+  const weatherVariants = Object.freeze([
+    Object.freeze({ kind: "thunderstorm", demandMultiplier: basisPoints(0) }),
+    Object.freeze({ kind: "cloudy", demandMultiplier: basisPoints(7_000) }),
+    Object.freeze({ kind: "sunny", demandMultiplier: basisPoints(10_000) }),
+    Object.freeze({ kind: "hot-and-dry", demandMultiplier: basisPoints(20_000) }),
+  ] as const);
+  const weather = Object.freeze(
+    weatherVariants.map((variant) =>
+      Object.freeze({
+        kind: variant.kind,
+        demand: Number(
+          potentialDemand(
+            moneyCents(10),
+            signCount(1),
+            Object.freeze({ weather: variant, sentiment: neutral.sentiment, event: neutral.event }),
+          ),
+        ),
+      }),
+    ),
+  );
+
+  const sentimentVariants = Object.freeze([
+    Object.freeze({ kind: "very-cold", demandMultiplier: basisPoints(8_500) }),
+    Object.freeze({ kind: "cold", demandMultiplier: basisPoints(9_250) }),
+    Object.freeze({ kind: "neutral", demandMultiplier: basisPoints(10_000) }),
+    Object.freeze({ kind: "warm", demandMultiplier: basisPoints(10_750) }),
+    Object.freeze({ kind: "hot", demandMultiplier: basisPoints(11_500) }),
+  ] as const);
+  const sentiment = Object.freeze(
+    sentimentVariants.map((variant) =>
+      Object.freeze({
+        kind: variant.kind,
+        demand: Number(
+          potentialDemand(
+            moneyCents(10),
+            signCount(1),
+            Object.freeze({ weather: neutral.weather, sentiment: variant, event: neutral.event }),
+          ),
+        ),
+      }),
+    ),
+  );
+
+  return Object.freeze({ priceDemand, advertising, weather, sentiment });
+};
+
+export const runBalanceCertification = (
+  horizonDays = CERTIFICATION_HORIZON_DAYS,
+  seedValues: readonly number[] = CERTIFICATION_SEEDS,
+): BalanceCertificationReport => {
+  requireInvariant(
+    Number.isSafeInteger(horizonDays) && horizonDays > 0,
+    "certification horizon must be a positive safe integer",
+  );
+  requireInvariant(seedValues.length > 0, "certification requires at least one seed");
+
+  const profiles = CERTIFICATION_STRATEGY_NAMES.map((name) => {
+    const strategy = strategies[name];
+    const runs = seedValues.map((value) => runStrategy(strategy, seed(value), horizonDays));
+    return aggregateProfile(strategy, runs);
+  });
+
+  return Object.freeze({
+    simulationSchemaVersion: SIMULATION_SCHEMA_VERSION,
+    horizonDays,
+    seeds: Object.freeze([...seedValues]),
+    profiles: Object.freeze(profiles),
+    probes: controlledProbes(),
+  });
+};
+
+const profile = (
+  report: BalanceCertificationReport,
+  name: CertificationStrategyName,
+): ProfileCertificationSummary => {
+  const result = report.profiles.find((candidate) => candidate.strategy === name);
+  if (result === undefined) return failCertification(`missing strategy profile ${name}`);
+  return result;
+};
+
+const demandAt = (
+  points: readonly Readonly<{ kind?: string; priceCents?: number; demand: number }>[],
+  predicate: (point: Readonly<{ kind?: string; priceCents?: number; demand: number }>) => boolean,
+): number => {
+  const point = points.find(predicate);
+  if (point === undefined) return failCertification("missing controlled demand probe");
+  return point.demand;
+};
+
+export const assertBalanceCertification = (report: BalanceCertificationReport): void => {
+  requireInvariant(
+    report.simulationSchemaVersion === SIMULATION_SCHEMA_VERSION,
+    "report simulation schema does not match the running engine",
+  );
+  requireInvariant(
+    report.profiles.length === CERTIFICATION_STRATEGY_NAMES.length,
+    "fixture corpus is incomplete",
+  );
+
+  for (const stableName of [
+    "conservative",
+    "advertising-heavy",
+    "adaptive",
+    "progression",
+  ] as const) {
+    requireInvariant(
+      profile(report, stableName).survivalRateBps === 10_000,
+      `${stableName} should survive the certification horizon across the fixed seed corpus`,
+    );
+  }
+
+  const conservative = profile(report, "conservative");
+  const advertisingHeavy = profile(report, "advertising-heavy");
+  const highPrice = profile(report, "high-price");
+  const poor = profile(report, "poor-decisions");
+  const adaptive = profile(report, "adaptive");
+  const progression = profile(report, "progression");
+
+  requireInvariant(
+    conservative.finalEquityCents.p50 >= 3_000,
+    "conservative median equity fell below the survivability guardrail",
+  );
+  requireInvariant(
+    adaptive.finalEquityCents.p50 >= 5_000,
+    "adaptive median equity fell below the growth guardrail",
+  );
+  requireInvariant(
+    progression.finalEquityCents.p50 >= 8_000,
+    "progression median equity fell below the tier-exercise guardrail",
+  );
+  requireInvariant(
+    poor.finalEquityCents.p50 < adaptive.finalEquityCents.p50,
+    "intentionally poor decisions should not outperform adaptive play",
+  );
+  requireInvariant(
+    highPrice.sellThroughBps < 7_000,
+    "high-price play no longer pays a material volume penalty",
+  );
+  requireInvariant(
+    advertisingHeavy.averageSignsHundredths > conservative.averageSignsHundredths + 300,
+    "advertising-heavy and conservative fixtures no longer exercise distinct advertising regimes",
+  );
+  requireInvariant(progression.maxTier === 4, "progression fixture must reach tier 4");
+  requireInvariant(
+    progression.earliestDayByTier.slice(0, 5).every((day) => day !== null),
+    "progression fixture must visit every current finance tier",
+  );
+
+  const medianEquities = report.profiles.map((item) => item.finalEquityCents.p50);
+  requireInvariant(
+    Math.max(...medianEquities) - Math.min(...medianEquities) >= 5_000,
+    "strategy outcomes collapsed into an insufficient equity spread",
+  );
+  const sellThrough = report.profiles.map((item) => item.sellThroughBps);
+  requireInvariant(
+    Math.max(...sellThrough) - Math.min(...sellThrough) >= 3_000,
+    "strategy outcomes collapsed into an insufficient sell-through spread",
+  );
+
+  const demandAtFive = demandAt(
+    report.probes.priceDemand,
+    (point) => point.priceCents === 5,
+  );
+  const demandAtTen = demandAt(
+    report.probes.priceDemand,
+    (point) => point.priceCents === 10,
+  );
+  const demandAtTwenty = demandAt(
+    report.probes.priceDemand,
+    (point) => point.priceCents === 20,
+  );
+  requireInvariant(
+    demandAtFive > demandAtTen && demandAtTen > demandAtTwenty,
+    "price/demand probe must remain strictly decreasing across 5c, 10c, and 20c",
+  );
+
+  const advertisingMarginals = report.probes.advertising
+    .filter((point) => point.signs > 0)
+    .map((point) => point.marginalDemand);
+  requireInvariant(
+    advertisingMarginals.length > 1 && (advertisingMarginals[0] ?? 0) > 0,
+    "advertising probe must produce positive first-sign demand",
+  );
+  for (let index = 1; index < advertisingMarginals.length; index += 1) {
+    const previous = advertisingMarginals[index - 1];
+    const current = advertisingMarginals[index];
+    if (previous === undefined || current === undefined) {
+      failCertification("advertising marginal probe is incomplete");
+    }
+    requireInvariant(current <= previous, "advertising marginal benefit must not increase with more signs");
+  }
+
+  const thunderstorm = demandAt(report.probes.weather, (point) => point.kind === "thunderstorm");
+  const cloudy = demandAt(report.probes.weather, (point) => point.kind === "cloudy");
+  const sunny = demandAt(report.probes.weather, (point) => point.kind === "sunny");
+  const hotAndDry = demandAt(report.probes.weather, (point) => point.kind === "hot-and-dry");
+  requireInvariant(
+    thunderstorm === 0 && cloudy < sunny && sunny < hotAndDry,
+    "weather demand ordering changed unexpectedly",
+  );
+
+  const veryCold = demandAt(report.probes.sentiment, (point) => point.kind === "very-cold");
+  const neutralSentiment = demandAt(report.probes.sentiment, (point) => point.kind === "neutral");
+  const hotSentiment = demandAt(report.probes.sentiment, (point) => point.kind === "hot");
+  requireInvariant(
+    veryCold < neutralSentiment && neutralSentiment < hotSentiment,
+    "market sentiment demand ordering changed unexpectedly",
+  );
+}
+
+const dollars = (cents: number): string => `$${(cents / 100).toFixed(2)}`;
+const percentFromBps = (bps: number): string => `${(bps / 100).toFixed(1)}%`;
+const decimalHundredths = (hundredths: number): string => (hundredths / 100).toFixed(2);
+
+export const formatBalanceCertification = (report: BalanceCertificationReport): string => {
+  const lines = [
+    "# Lemonade balance certification",
+    "",
+    `Simulation schema: ${String(report.simulationSchemaVersion)}`,
+    `Corpus: ${String(report.profiles.length)} strategies × ${String(report.seeds.length)} seeds × up to ${String(report.horizonDays)} days`,
+    "",
+    "| Strategy | Survival | Equity p50 | Equity p90 | Sell-through | Avg price | Avg signs | Max tier |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  ];
+
+  for (const item of report.profiles) {
+    lines.push(
+      `| ${item.strategy} | ${percentFromBps(item.survivalRateBps)} | ${dollars(item.finalEquityCents.p50)} | ${dollars(item.finalEquityCents.p90)} | ${percentFromBps(item.sellThroughBps)} | ${(item.averagePriceHundredthsOfCent / 100).toFixed(2)}¢ | ${decimalHundredths(item.averageSignsHundredths)} | ${String(item.maxTier)} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Signal and event sensitivity",
+    "",
+    "| Strategy | Weather Δ demand/day | Sentiment Δ demand/day | Exceptional-event rate | Event impact/day |",
+    "| --- | ---: | ---: | ---: | ---: |",
+  );
+  for (const item of report.profiles) {
+    lines.push(
+      `| ${item.strategy} | ${decimalHundredths(item.weatherContributionHundredths)} | ${decimalHundredths(item.sentimentContributionHundredths)} | ${percentFromBps(item.exceptionalEventRateBps)} | ${decimalHundredths(item.eventImpactHundredths)} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Finance burden across the corpus",
+    "",
+    "| Strategy | Taxes | Supplier fees | Bank fees | Loan interest | Borrowed | Repaid | Savings interest |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  );
+  for (const item of report.profiles) {
+    lines.push(
+      `| ${item.strategy} | ${dollars(item.finance.taxesCents)} | ${dollars(item.finance.supplierFeesCents)} | ${dollars(item.finance.bankFeesCents)} | ${dollars(item.finance.loanInterestCents)} | ${dollars(item.finance.borrowedCents)} | ${dollars(item.finance.repaidCents)} | ${dollars(item.finance.savingsInterestCents)} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Controlled probes",
+    "",
+    `Price → demand: ${report.probes.priceDemand.map((point) => `${String(point.priceCents)}¢=${String(point.demand)}`).join(", ")}`,
+    `Signs → demand (marginal): ${report.probes.advertising.map((point) => `${String(point.signs)}=${String(point.demand)} (+${String(point.marginalDemand)})`).join(", ")}`,
+    `Weather → demand: ${report.probes.weather.map((point) => `${point.kind}=${String(point.demand)}`).join(", ")}`,
+    `Sentiment → demand: ${report.probes.sentiment.map((point) => `${point.kind}=${String(point.demand)}`).join(", ")}`,
+    "",
+    "Certification guardrails: PASS",
+  );
+
+  return lines.join("\n");
+};

--- a/packages/simulation/src/certification.ts
+++ b/packages/simulation/src/certification.ts
@@ -634,7 +634,7 @@ const controlledProbes = (): ControlledProbes => {
 };
 
 export const runBalanceCertification = (
-  horizonDays = CERTIFICATION_HORIZON_DAYS,
+  horizonDays: number = CERTIFICATION_HORIZON_DAYS,
   seedValues: readonly number[] = CERTIFICATION_SEEDS,
 ): BalanceCertificationReport => {
   requireInvariant(

--- a/packages/simulation/src/certification.ts
+++ b/packages/simulation/src/certification.ts
@@ -1,4 +1,5 @@
-import { availableOperatingFunds, financeRulesForTier, predictableFixedObligations } from "./finance.js";
+import { generateEnvironment, neutralEnvironment } from "./environment.js";
+import { availableOperatingFunds, predictableFixedObligations } from "./finance.js";
 import type {
   DailyLedgerEntry,
   DayDecision,
@@ -17,11 +18,10 @@ import {
   type Seed,
 } from "./primitives.js";
 import { createSeededRandom } from "./rng.js";
-import { generateEnvironment, neutralEnvironment } from "./environment.js";
 import { potentialDemand } from "./rules.js";
 import { simulateDay } from "./simulate.js";
 import { createInitialState } from "./state.js";
-import { SIMULATION_SCHEMA_VERSION } from "./index.js";
+import { SIMULATION_SCHEMA_VERSION } from "./version.js";
 
 export const CERTIFICATION_HORIZON_DAYS = 90 as const;
 
@@ -176,6 +176,12 @@ const failCertification = (message: string): never => {
 
 const requireInvariant = (condition: boolean, message: string): void => {
   if (!condition) failCertification(message);
+};
+
+const valueAt = <Value>(values: readonly Value[], index: number, label: string): Value => {
+  const value = values[index];
+  if (value === undefined) return failCertification(`${label} is incomplete`);
+  return value;
 };
 
 const variableBudgetCents = (state: GameState): number =>
@@ -362,9 +368,7 @@ const demandContribution = (
   entry: DailyLedgerEntry,
 ): Readonly<{ weather: number; sentiment: number; event: number }> => {
   const neutral = neutralEnvironment();
-  const neutralDemand = Number(
-    potentialDemand(entry.decision.price, entry.decision.signs, neutral),
-  );
+  const neutralDemand = Number(potentialDemand(entry.decision.price, entry.decision.signs, neutral));
   const weatherOnly: DayEnvironment = Object.freeze({
     weather: entry.environment.weather,
     sentiment: neutral.sentiment,
@@ -475,15 +479,10 @@ const runStrategy = (
   });
 };
 
-const sorted = (values: readonly number[]): number[] => [...values].sort((a, b) => a - b);
-
 const percentile = (values: readonly number[], ratio: number): number => {
   if (values.length === 0) return failCertification("cannot summarize an empty value set");
-  const ordered = sorted(values);
-  const index = Math.floor((ordered.length - 1) * ratio);
-  const value = ordered[index];
-  if (value === undefined) return failCertification("percentile index escaped value set");
-  return value;
+  const ordered = [...values].sort((a, b) => a - b);
+  return valueAt(ordered, Math.floor((ordered.length - 1) * ratio), "percentile values");
 };
 
 const aggregateFinance = (runs: readonly CertificationRunSummary[]): FinanceBurden =>
@@ -668,9 +667,11 @@ const profile = (
   return result;
 };
 
+type DemandProbePoint = Readonly<{ kind?: string; priceCents?: number; demand: number }>;
+
 const demandAt = (
-  points: readonly Readonly<{ kind?: string; priceCents?: number; demand: number }>[],
-  predicate: (point: Readonly<{ kind?: string; priceCents?: number; demand: number }>) => boolean,
+  points: readonly DemandProbePoint[],
+  predicate: (point: DemandProbePoint) => boolean,
 ): number => {
   const point = points.find(predicate);
   if (point === undefined) return failCertification("missing controlled demand probe");
@@ -747,18 +748,9 @@ export const assertBalanceCertification = (report: BalanceCertificationReport): 
     "strategy outcomes collapsed into an insufficient sell-through spread",
   );
 
-  const demandAtFive = demandAt(
-    report.probes.priceDemand,
-    (point) => point.priceCents === 5,
-  );
-  const demandAtTen = demandAt(
-    report.probes.priceDemand,
-    (point) => point.priceCents === 10,
-  );
-  const demandAtTwenty = demandAt(
-    report.probes.priceDemand,
-    (point) => point.priceCents === 20,
-  );
+  const demandAtFive = demandAt(report.probes.priceDemand, (point) => point.priceCents === 5);
+  const demandAtTen = demandAt(report.probes.priceDemand, (point) => point.priceCents === 10);
+  const demandAtTwenty = demandAt(report.probes.priceDemand, (point) => point.priceCents === 20);
   requireInvariant(
     demandAtFive > demandAtTen && demandAtTen > demandAtTwenty,
     "price/demand probe must remain strictly decreasing across 5c, 10c, and 20c",
@@ -768,15 +760,12 @@ export const assertBalanceCertification = (report: BalanceCertificationReport): 
     .filter((point) => point.signs > 0)
     .map((point) => point.marginalDemand);
   requireInvariant(
-    advertisingMarginals.length > 1 && (advertisingMarginals[0] ?? 0) > 0,
+    advertisingMarginals.length > 1 && valueAt(advertisingMarginals, 0, "advertising marginal probe") > 0,
     "advertising probe must produce positive first-sign demand",
   );
   for (let index = 1; index < advertisingMarginals.length; index += 1) {
-    const previous = advertisingMarginals[index - 1];
-    const current = advertisingMarginals[index];
-    if (previous === undefined || current === undefined) {
-      failCertification("advertising marginal probe is incomplete");
-    }
+    const previous = valueAt(advertisingMarginals, index - 1, "advertising marginal probe");
+    const current = valueAt(advertisingMarginals, index, "advertising marginal probe");
     requireInvariant(current <= previous, "advertising marginal benefit must not increase with more signs");
   }
 
@@ -796,7 +785,7 @@ export const assertBalanceCertification = (report: BalanceCertificationReport): 
     veryCold < neutralSentiment && neutralSentiment < hotSentiment,
     "market sentiment demand ordering changed unexpectedly",
   );
-}
+};
 
 const dollars = (cents: number): string => `$${(cents / 100).toFixed(2)}`;
 const percentFromBps = (bps: number): string => `${(bps / 100).toFixed(1)}%`;

--- a/packages/simulation/src/index.ts
+++ b/packages/simulation/src/index.ts
@@ -1,5 +1,4 @@
-export const SIMULATION_SCHEMA_VERSION = 2 as const;
-
+export * from "./certification.js";
 export * from "./environment.js";
 export * from "./finance.js";
 export * from "./model.js";
@@ -8,3 +7,4 @@ export * from "./rng.js";
 export * from "./rules.js";
 export * from "./simulate.js";
 export * from "./state.js";
+export * from "./version.js";

--- a/packages/simulation/src/version.ts
+++ b/packages/simulation/src/version.ts
@@ -1,0 +1,1 @@
+export const SIMULATION_SCHEMA_VERSION = 2 as const;

--- a/packages/simulation/test/certification.test.ts
+++ b/packages/simulation/test/certification.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CERTIFICATION_HORIZON_DAYS,
+  CERTIFICATION_SEEDS,
+  CERTIFICATION_STRATEGY_NAMES,
+  assertBalanceCertification,
+  formatBalanceCertification,
+  runBalanceCertification,
+} from "../src/index.js";
+
+describe("balance certification", () => {
+  it("produces deterministic output for the fixed fixture corpus", () => {
+    const first = runBalanceCertification();
+    const second = runBalanceCertification();
+
+    expect(second).toEqual(first);
+    expect(first.horizonDays).toBe(CERTIFICATION_HORIZON_DAYS);
+    expect(first.seeds).toEqual(CERTIFICATION_SEEDS);
+    expect(first.profiles.map((profile) => profile.strategy)).toEqual(
+      CERTIFICATION_STRATEGY_NAMES,
+    );
+  });
+
+  it("passes accounting, progression, and strategic guardrails", () => {
+    const report = runBalanceCertification();
+
+    expect(() => {
+      assertBalanceCertification(report);
+    }).not.toThrow();
+
+    const progression = report.profiles.find((profile) => profile.strategy === "progression");
+    expect(progression?.maxTier).toBe(4);
+    expect(progression?.earliestDayByTier.slice(0, 5).every((day) => day !== null)).toBe(true);
+  });
+
+  it("formats a human-reviewable deterministic report", () => {
+    const text = formatBalanceCertification(runBalanceCertification());
+
+    expect(text).toContain("# Lemonade balance certification");
+    expect(text).toContain("advertising-heavy");
+    expect(text).toContain("Finance burden across the corpus");
+    expect(text).toContain("Controlled probes");
+    expect(text).toContain("Certification guardrails: PASS");
+  });
+});

--- a/scripts/certify.mjs
+++ b/scripts/certify.mjs
@@ -1,0 +1,9 @@
+import {
+  assertBalanceCertification,
+  formatBalanceCertification,
+  runBalanceCertification,
+} from "../packages/simulation/dist/certification.js";
+
+const report = runBalanceCertification();
+assertBalanceCertification(report);
+console.log(formatBalanceCertification(report));


### PR DESCRIPTION
## Scope
Begins Phase 9 / #22 by turning balance and gameplay feel into a repeatable pure-simulation certification loop.

- adds seven fixed strategy profiles across sixteen deterministic seeds and a 90-day horizon
- validates accounting, inventory, cash-flow, debt, day, and ledger invariants on every simulated day
- captures survival/bankruptcy, equity distribution, sell-through/waste, price/sign behavior, event frequency/impact, environment contribution, tier timing, and finance burden
- adds controlled price, advertising, weather, and sentiment probes
- enforces broad design guardrails without encoding a single optimal strategy
- requires the progression fixture to visit every current finance tier
- exposes `pnpm certify` for a deterministic Markdown report
- adds Vitest coverage so CI fails on broken invariants or clearly impossible balance regressions
- documents which results are hard invariants, design guardrails, and human-review metrics
- adds no analytics/runtime dependency and does not involve browser/rendering/audio/storage code

This PR intentionally makes balance movement inspectable rather than auto-tuning constants.

Refs #22