### PR TITLE
fix: deploy modern web app to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm certify
+      - name: Verify GitHub Pages bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm --filter @lemonade/web exec vite build --base=/Lemonade/
+          test -f apps/web/dist/index.html
+          grep -q '/Lemonade/assets/' apps/web/dist/index.html
 
   browser:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,13 +16,34 @@ jobs:
   publish:
     name: Publish gh-pages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Publish public to gh-pages
+      - name: Setup pnpm and Node
+        uses: pnpm/setup@v1
+        with:
+          runtime: node@24
+          cache: true
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project-page bundle
+        run: pnpm --filter @lemonade/web exec vite build --base=/Lemonade/
+
+      - name: Verify deployment bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f apps/web/dist/index.html
+          grep -q '/Lemonade/assets/' apps/web/dist/index.html
+
+      - name: Publish build to gh-pages
         shell: bash
         run: |
           set -euo pipefail
@@ -34,7 +55,7 @@ jobs:
           git worktree add --detach "$RUNNER_TEMP/gh-pages" origin/gh-pages
 
           find "$RUNNER_TEMP/gh-pages" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-          cp -a public/. "$RUNNER_TEMP/gh-pages/"
+          cp -a apps/web/dist/. "$RUNNER_TEMP/gh-pages/"
           touch "$RUNNER_TEMP/gh-pages/.nojekyll"
 
           cd "$RUNNER_TEMP/gh-pages"


### PR DESCRIPTION
## Scope
Restore GitHub Pages deployment after the legacy `public/` tree was removed during modernization.

- build the current `@lemonade/web` Vite application in the Pages workflow
- use `/Lemonade/` as the project-page base path
- publish `apps/web/dist` to `gh-pages`
- verify the generated HTML references `/Lemonade/assets/`
- add the same project-page bundle verification to CI so future workspace cleanups cannot silently break deployment

This is an MVP deployment blocker and should merge only after CI is green.