### PR TITLE
test: certify the production MVP artifact

### DIFF
--- a/docs/certification.md
+++ b/docs/certification.md
@@ -1,0 +1,69 @@
+# MVP release certification
+
+Lemonade uses an internal release-certification gate for the browser MVP. This is a repeatable engineering/product release standard, not a claim of third-party certification or formal conformance to every requirement of an external standard.
+
+## Certified surface
+
+The certified MVP is the static browser application deployed beneath the GitHub Pages project path `/Lemonade/`.
+
+The release surface includes:
+
+- the three operating decisions: glasses, signs, and price;
+- the single daily Sell action and day report;
+- deterministic weather, sentiment, exceptional events, and finance progression;
+- the immutable financial ledger and accessible chart/table history;
+- vector 3D presentation plus textual scene equivalence;
+- procedural Web Audio with explicit user activation;
+- IndexedDB run persistence, reload restoration, import/export, reset, recovery, and in-memory degradation when durable storage fails.
+
+Optional Tauri/native capabilities are outside the browser MVP certification boundary until a concrete native product benefit is demonstrated.
+
+## Required gates
+
+A revision is release-certified only when all of the following pass for the same `master` revision:
+
+1. `pnpm check`
+   - strict TypeScript;
+   - type-aware ESLint;
+   - unit/invariant tests;
+   - production workspace build.
+2. `pnpm certify`
+   - the fixed deterministic strategy/seed corpus;
+   - accounting, inventory, progression, demand, environment, and finance guardrails;
+   - deterministic human-reviewable balance output.
+3. `pnpm test:e2e`
+   - Playwright runs against a built Vite production bundle, not the development server;
+   - the bundle and preview use the same `/Lemonade/` base path as GitHub Pages;
+   - keyboard daily-loop completion;
+   - affordability validation;
+   - report and next-day reload restoration;
+   - clean-profile export/import portability;
+   - no uncaught page or console errors through the certified daily flow;
+   - 360 px viewport containment without document-level horizontal overflow;
+   - semantic table equivalents for historical charts;
+   - reduced-motion media behavior;
+   - playable in-memory degradation when IndexedDB fails.
+4. GitHub Pages bundle verification
+   - `apps/web/dist/index.html` exists;
+   - generated asset URLs use `/Lemonade/assets/`.
+5. Post-merge deployment
+   - CI passes again on `master`;
+   - the Pages publisher successfully builds and pushes that revision to `gh-pages`.
+
+The exact `master` and deployment revisions for a certification event are recorded on the certification issue so the evidence cannot become ambiguous as development continues.
+
+## Balance evidence
+
+Balance certification is intentionally based on ranges and directional guardrails rather than one golden outcome. The corpus currently covers conservative, aggressive inventory, advertising-heavy, high-price, intentionally poor, adaptive, and progression strategies across sixteen fixed seeds and a 90-day horizon.
+
+Changing a balance guardrail is a product decision. It must include the intended player-behavior rationale and note any simulation-schema or deterministic replay implications.
+
+## Accessibility boundary
+
+Release certification verifies the accessibility-critical behaviors implemented by the project: semantic native controls, keyboard operation, accessible chart/table equivalents, nonvisual scene text, reduced-motion behavior, responsive containment, and status/error messaging.
+
+It does not represent an external WCAG audit or accessibility certification. If the project later claims a particular WCAG conformance level, that claim requires a separate criterion-by-criterion audit with documented evidence.
+
+## Certification maintenance
+
+Do not weaken a release assertion merely because a legitimate product regression makes CI fail. Fix the regression or explicitly revise the certification contract with rationale. New mandatory daily controls require product-level review because the three-decision operating surface is a core game invariant.

--- a/e2e/certification.spec.ts
+++ b/e2e/certification.spec.ts
@@ -1,5 +1,96 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-const assertNoHorizontalOverflow = async (page: Parameters<typeof test>[0] extends never ? never : never) => {
-  void page;
+const expectNoHorizontalOverflow = async (page: Page): Promise<void> => {
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
 };
+
+test("release artifact completes a day without uncaught runtime failures", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  await page.goto("./");
+  await expect(page.getByRole("main")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Lemonade", level: 1 })).toBeVisible();
+  await expect(page.getByRole("slider")).toHaveCount(3);
+  await expect(page.locator("#scene-equivalent")).not.toBeEmpty();
+
+  await page.getByRole("button", { name: "Sell for the day" }).click();
+  await expect(page.getByRole("button", { name: "Plan next day" })).toBeVisible();
+  await page.getByRole("button", { name: "Plan next day" }).click();
+  await expect(page.locator("#status-day")).toHaveText("2");
+
+  expect(consoleErrors).toEqual([]);
+  expect(pageErrors).toEqual([]);
+});
+
+test("narrow viewport keeps the operating surface contained and data accessible", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 740 });
+  await page.goto("./");
+
+  await expectNoHorizontalOverflow(page);
+  await expect(page.getByRole("slider", { name: /Glasses/ })).toBeVisible();
+  await expect(page.getByRole("slider", { name: /Signs/ })).toBeVisible();
+  await expect(page.getByRole("slider", { name: /Price/ })).toBeVisible();
+
+  await page.getByRole("button", { name: "Sell for the day" }).click();
+  const history = page.getByRole("region", { name: "Sales history" });
+  await expect(history).toBeVisible();
+  await expect(
+    history.getByRole("table", {
+      name: "Complete values represented by the sales-history charts and finance ledger",
+    }),
+  ).toBeVisible();
+  await expect(history.getByRole("img")).toHaveCount(2);
+  await expectNoHorizontalOverflow(page);
+});
+
+test("reduced-motion preference collapses decorative transition and animation durations", async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("./");
+
+  await expect
+    .poll(() => page.evaluate(() => window.matchMedia("(prefers-reduced-motion: reduce)").matches))
+    .toBe(true);
+
+  const durations = await page.getByRole("button", { name: "Sell for the day" }).evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    return {
+      animationSeconds: Number.parseFloat(style.animationDuration),
+      transitionSeconds: Number.parseFloat(style.transitionDuration),
+    };
+  });
+
+  expect(durations.animationSeconds).toBeLessThanOrEqual(0.001);
+  expect(durations.transitionSeconds).toBeLessThanOrEqual(0.001);
+  await page.getByRole("button", { name: "Sell for the day" }).click();
+  await expect(page.getByRole("button", { name: "Plan next day" })).toBeVisible();
+});
+
+test("storage failure degrades to a playable in-memory run", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      get() {
+        throw new Error("certification-injected IndexedDB failure");
+      },
+    });
+  });
+
+  await page.goto("./");
+  await expect(page.locator("#run-error")).toContainText("Unable to open browser run storage");
+  await expect(page.getByRole("button", { name: "Sell for the day" })).toBeEnabled();
+  await page.getByRole("button", { name: "Sell for the day" }).click();
+  await expect(page.getByRole("button", { name: "Plan next day" })).toBeVisible();
+});

--- a/e2e/certification.spec.ts
+++ b/e2e/certification.spec.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "@playwright/test";
+
+const assertNoHorizontalOverflow = async (page: Parameters<typeof test>[0] extends never ? never : never) => {
+  void page;
+};

--- a/e2e/daily-loop.spec.ts
+++ b/e2e/daily-loop.spec.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { expect, test } from "@playwright/test";
 
 test("plays a complete day with keyboard controls", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
 
   const sliders = page.getByRole("slider");
   await expect(sliders).toHaveCount(3);
@@ -22,7 +22,7 @@ test("plays a complete day with keyboard controls", async ({ page }) => {
 });
 
 test("prevents an unaffordable plan before submission", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
 
   const glasses = page.getByRole("slider", { name: /Glasses/ });
   const signs = page.getByRole("slider", { name: /Signs/ });
@@ -36,7 +36,7 @@ test("prevents an unaffordable plan before submission", async ({ page }) => {
 });
 
 test("restores both report and next-day phases across reloads", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await page.getByRole("button", { name: "Sell for the day" }).click();
 
   const reportHeading = page.getByRole("heading", { name: /sold$/ });
@@ -59,10 +59,10 @@ test("restores both report and next-day phases across reloads", async ({ page })
 });
 
 test("exports and imports a progressed run into a clean browser profile", async ({ browser }) => {
-  const baseURL = "http://127.0.0.1:4173";
+  const baseURL = "http://127.0.0.1:4173/Lemonade/";
   const source = await browser.newContext({ baseURL, acceptDownloads: true });
   const sourcePage = await source.newPage();
-  await sourcePage.goto("/");
+  await sourcePage.goto("./");
   await sourcePage.getByRole("button", { name: "Sell for the day" }).click();
   await sourcePage.getByRole("button", { name: "Plan next day" }).click();
   await expect(sourcePage.locator("#status-day")).toHaveText("2");
@@ -75,7 +75,7 @@ test("exports and imports a progressed run into a clean browser profile", async 
 
   const target = await browser.newContext({ baseURL });
   const targetPage = await target.newPage();
-  await targetPage.goto("/");
+  await targetPage.goto("./");
   await expect(targetPage.locator("#status-day")).toHaveText("1");
 
   const chooserPromise = targetPage.waitForEvent("filechooser");

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
 const isCI = Boolean(process.env["CI"]);
+const basePath = "/Lemonade/";
+const previewOrigin = "http://127.0.0.1:4173";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -9,12 +11,12 @@ export default defineConfig({
   retries: isCI ? 2 : 0,
   reporter: isCI ? "github" : "list",
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: `${previewOrigin}${basePath}`,
     trace: "on-first-retry",
   },
   webServer: {
-    command: "pnpm --filter @lemonade/web dev --host 127.0.0.1 --port 4173",
-    url: "http://127.0.0.1:4173",
+    command: `pnpm --filter @lemonade/web exec vite build --base=${basePath} && pnpm --filter @lemonade/web exec vite preview --host 127.0.0.1 --port 4173 --strictPort --base=${basePath}`,
+    url: `${previewOrigin}${basePath}`,
     reuseExistingServer: !isCI,
   },
 });


### PR DESCRIPTION
## Release certification

This PR tightens browser acceptance so it certifies the artifact we actually deploy.

- build Vite with `/Lemonade/` and run Playwright against `vite preview`
- update all existing daily-loop/persistence/portability acceptance flows to the GitHub Pages base path
- fail on uncaught page/console errors during a complete day
- verify the three-control operating surface and scene text equivalent
- certify 360px layout containment and semantic chart/table equivalents
- verify reduced-motion media behavior
- verify IndexedDB failure degrades to a playable in-memory run

No runtime dependency or product control is added.

Closes #28 once this PR, post-merge CI, and GitHub Pages deployment are green.